### PR TITLE
add missing documentation

### DIFF
--- a/Sources/NSDate+Extensions.swift
+++ b/Sources/NSDate+Extensions.swift
@@ -39,9 +39,13 @@ extension NSDate {
      - `HourMinuteSecondPeriod` (e.g. "07:41:30 PM")
      */
     public enum TimeFormat {
+        /// Military time with hours and minutes (e.g. "19:41")
         case HourMinuteMilitary
+        /// Standard time with hours and minutes (e.g. "07:41 PM")
         case HourMinutePeriod
+        /// Military time with hours, minutes, and seconds (e.g. "19:41:30")
         case HourMinuteSecondMilitary
+        /// Standard time with hours, minutes, and seconds (e.g. "07:41:30 PM")
         case HourMinuteSecondPeriod
         
         /// Time period (i.e. `AM` and `PM`)
@@ -323,10 +327,12 @@ extension NSDate {
 
 extension NSDate: Comparable {}
 
+/// Returns true if both dates are equal to each other.
 public func ==(lhs: NSDate, rhs: NSDate) -> Bool {
     return lhs === rhs || lhs.compare(rhs) == .OrderedSame
 }
 
+/// Returns true if the first date is less than the second date.
 public func <(lhs: NSDate, rhs: NSDate) -> Bool {
     return lhs.compare(rhs) == .OrderedAscending
 }

--- a/Sources/UIGestureRecognizer+Extensions.swift
+++ b/Sources/UIGestureRecognizer+Extensions.swift
@@ -32,12 +32,11 @@
 
 import Foundation
 
-
 extension UIGestureRecognizer {
     private class GestureAction {
-        var action: UIGestureRecognizer -> Void
+        var action: (UIGestureRecognizer) -> Void
         
-        init(action: UIGestureRecognizer -> Void) {
+        init(action: (UIGestureRecognizer) -> Void) {
             self.action = action
         }
     }
@@ -59,13 +58,13 @@ extension UIGestureRecognizer {
      
      - returns: The UIGestureRecognizer.
      */
-    public convenience init(action: UIGestureRecognizer -> Void) {
+    public convenience init(action: (UIGestureRecognizer) -> Void) {
         self.init()
         gestureAction = GestureAction(action: action)
         addTarget(self, action: "handleAction:")
     }
     
-    final public func handleAction(recognizer: UIGestureRecognizer) {
+    dynamic private func handleAction(recognizer: UIGestureRecognizer) {
         gestureAction?.action(recognizer)
     }
 }

--- a/Sources/UIScreen+Extensions.swift
+++ b/Sources/UIScreen+Extensions.swift
@@ -31,45 +31,6 @@ import UIKit
 
 extension UIScreen {
     
-    // Hsoi 2014-10-09 - iOS 8 changed such things regarding view geometry are now
-    // orientation-dependent. Thus where under iOS 7 the +[[UIScreen mainScreen] bounds] would
-    // result in:
-    //
-    //  Portrait:   width: 320.0,   height: 568.00
-    //  Landscape:  width: 320.0,   height: 568.00
-    //
-    // (against the [[UIApplication sharedApplication] statusBarOrientation], so UIInterfaceOrientation)
-    //
-    // in iOS8 you get:
-    //
-    //  Portrait:   width: 320.0,   height: 568.0
-    //  Landscape:  width: 568.0    height: 320.0
-    //
-    // Based upon: http://stackoverflow.com/questions/24150359/is-uiscreen-mainscreen-bounds-size-becoming-orientation-dependent-in-ios8
-    // we have this category extension method of +ONE_size to get the height/width of the +[UIScreen mainScreen]
-    // that should fit expectation regarding screen width and height relative to orientation and OS version.
-    //
-    // Thus, regardless of OS version, what you get is:
-    //
-    //  Portrait:   width: 320.0,   height: 568.0
-    //  Landscape:  width: 568.0    height: 320.0
-
-    // TODO: Hsoi 2015-01-21 - Convert to a class variable, when Swift supports them.
-    //
-    // I originally wrote this functionality in Objective-C and wrote it as a class method so you could just
-    // `+[UIScreen orientedSize]` and be done with it (since on iOS we generally only care about the mainScreen).
-    // When converting to Swift, I figured the right thing would be to make this a computed read-only property, but
-    // then it would need to be a class variable, which Swift doesn't yet support. So for now, it's a class func.
-    
-    public class func orientedSize() -> CGSize {
-        var screenSize = UIScreen.mainScreen().bounds.size
-        let interfaceOrientation = UIApplication.sharedApplication().statusBarOrientation
-        if (NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_7_1) && UIInterfaceOrientationIsLandscape(interfaceOrientation) {
-            screenSize = CGSizeMake(screenSize.height, screenSize.width)
-        }
-        return screenSize
-    }
-    
     /// The center of the screen
     public var center: CGPoint {
         return CGPoint(x: width/2, y: height/2)
@@ -77,12 +38,12 @@ extension UIScreen {
     
     /// The width of the screen
     public var width: CGFloat {
-        return CGRectGetWidth(self.bounds)
+        return bounds.width
     }
     
     /// The height of the screen
     public var height: CGFloat {
-        return CGRectGetHeight(self.bounds)
+        return bounds.height
     }
     
     /// The center of the main screen


### PR DESCRIPTION
- Removed `orientedSize()` method on UIScreen. It's only useful for pre-iOS 8 projects, and since this repo only supports iOS 8+, the method is no longer necessary.
- The only remaining "undocumented" code is the `Key` generic type parameter on the Dictionary operators. The operators _are_ documented, but there's currently an open [issue](https://github.com/realm/jazzy/issues/429) on [Jazzy](https://github.com/realm/jazzy) for mistakenly marking generic type parameters as "undocumented."