### PR TITLE
Allow initializing UIColor with Integers

### DIFF
--- a/Sources/UIColor+Extensions.swift
+++ b/Sources/UIColor+Extensions.swift
@@ -65,7 +65,9 @@ extension UIColor {
      - parameter alpha: CGFloat representation of the alpha component in range of 0-1
     */
     @nonobjc
-    public convenience init(red: Int, green: Int, blue: Int, alpha: CGFloat = 1.0) {
+    public convenience init(red: UInt8, green: UInt8, blue: UInt8, alpha: CGFloat = 1.0) {
+        assert(alpha >= 0 && alpha <= 1, "The alpha component must be between 0 and 1")
+        
         self.init(red: CGFloat(red)/255.0, green: CGFloat(green)/255.0, blue: CGFloat(blue)/255.0, alpha: alpha)
     }
     

--- a/Sources/UIColor+Extensions.swift
+++ b/Sources/UIColor+Extensions.swift
@@ -57,6 +57,18 @@ extension UIColor {
         self.init(hex: hexEquivalent)
     }
     
+    /**
+     Returns a UIColor initialized with color components divided by 255.0.
+     - parameter red: Integer representation of the red component in range of 0-255
+     - parameter green: Integer representation of the green component in range of 0-255
+     - parameter blue: Integer representation of the blue component in range of 0-255
+     - parameter alpha: CGFloat representation of the alpha component in range of 0-1
+    */
+    @nonobjc
+    public convenience init(red: Int, green: Int, blue: Int, alpha: CGFloat = 1.0) {
+        self.init(red: CGFloat(red)/255.0, green: CGFloat(green)/255.0, blue: CGFloat(blue)/255.0, alpha: alpha)
+    }
+    
     /// Returns a random UIColor with hue, saturation, and brightness ranging from 0.5 to 1.0.
     public static func randomColor() -> UIColor {
         let component = { CGFloat(arc4random() % 128)/256.0 + 0.5 }


### PR DESCRIPTION
A convenience initializer for UIColor to use Ints such as `225` instead of floats like `225.0/255.0`.