### PR TITLE
Removing the alpha argument to make the UIColor convenience initializer unique

### DIFF
--- a/Sources/UIColor+Extensions.swift
+++ b/Sources/UIColor+Extensions.swift
@@ -63,7 +63,6 @@ extension UIColor {
      - parameter green: Integer representation of the green component in range of 0-255
      - parameter blue: Integer representation of the blue component in range of 0-255
     */
-    @nonobjc
     public convenience init(red: UInt8, green: UInt8, blue: UInt8) {
         self.init(red: CGFloat(red)/255.0, green: CGFloat(green)/255.0, blue: CGFloat(blue)/255.0, alpha: 1.0)
     }

--- a/Sources/UIColor+Extensions.swift
+++ b/Sources/UIColor+Extensions.swift
@@ -62,13 +62,10 @@ extension UIColor {
      - parameter red: Integer representation of the red component in range of 0-255
      - parameter green: Integer representation of the green component in range of 0-255
      - parameter blue: Integer representation of the blue component in range of 0-255
-     - parameter alpha: CGFloat representation of the alpha component in range of 0-1
     */
     @nonobjc
-    public convenience init(red: UInt8, green: UInt8, blue: UInt8, alpha: CGFloat = 1.0) {
-        assert(alpha >= 0 && alpha <= 1, "The alpha component must be between 0 and 1")
-        
-        self.init(red: CGFloat(red)/255.0, green: CGFloat(green)/255.0, blue: CGFloat(blue)/255.0, alpha: alpha)
+    public convenience init(red: UInt8, green: UInt8, blue: UInt8) {
+        self.init(red: CGFloat(red)/255.0, green: CGFloat(green)/255.0, blue: CGFloat(blue)/255.0, alpha: 1.0)
     }
     
     /// Returns a random UIColor with hue, saturation, and brightness ranging from 0.5 to 1.0.


### PR DESCRIPTION
Originally I had code like this:

`UIColor(red: 78/255, green: 43/255, blue: 96/255, alpha: 1)`

Which was fine until I added Alexandria. But now I get an error:

> Ambiguous use of operator `/`

So ok... I change it: `UIColor(red: 81, green: 45, blue: 109, alpha: 1)` and now:

> ambiguous use of `init(red:green:blue:alpha:)`

I guess this is an interesting case... we're overloading the function -- the NAME of the function is the same, but the argument types are not.

if I remove the explicit alpha argument, no problems....


And so, after some discussion, we agreed to just remove the `alpha` argument because it's a convenience initializer and we're using it for shortcuts/convenience. Most of the time you'll want a 1.0 alpha anyways so... this just makes it a little more convenient.