### PR TITLE
isNumeric string extension

### DIFF
--- a/AlexandriaTests/StringTests.swift
+++ b/AlexandriaTests/StringTests.swift
@@ -71,4 +71,12 @@ class StringTests: XCTestCase {
         XCTAssertEqual("hello there".truncate(5), "hello", "Truncated strings are not equal")
         XCTAssertEqual("hello there".truncate(5, trailing: "..."), "hello...", "Truncated strings are not equal")
     }
+    
+    func testNumeric() {
+        XCTAssert("".isNumeric(), "Empty string is numeric")
+        XCTAssert("12345678901234567890".isNumeric(), "Long string of integers is numeric")
+        XCTAssertFalse("12.34".isNumeric(), "String containing decimal point is not numeric")
+        XCTAssertFalse("a".isNumeric(), "String containing only letters is not numeric")
+        XCTAssertFalse("1A1".isNumeric(), "String containing letters and number is not numeric")
+    }
 }

--- a/AlexandriaTests/StringTests.swift
+++ b/AlexandriaTests/StringTests.swift
@@ -73,10 +73,12 @@ class StringTests: XCTestCase {
     }
     
     func testNumeric() {
-        XCTAssert("".isNumeric(), "Empty string is numeric")
-        XCTAssert("12345678901234567890".isNumeric(), "Long string of integers is numeric")
-        XCTAssertFalse("12.34".isNumeric(), "String containing decimal point is not numeric")
-        XCTAssertFalse("a".isNumeric(), "String containing only letters is not numeric")
-        XCTAssertFalse("1A1".isNumeric(), "String containing letters and number is not numeric")
+        XCTAssert("1".isNumeric, "Simple string of one digit is numberic")
+        XCTAssert("12345678901234567890".isNumeric, "String of many digits is numeric")
+        XCTAssertFalse("".isNumeric, "Empty string is not numeric")
+        XCTAssertFalse("12.34".isNumeric, "String containing decimal point is not numeric")
+        XCTAssertFalse("a".isNumeric, "String containing only letters is not numeric")
+        XCTAssertFalse("1a1".isNumeric, "String containing letters and digits is not numeric")
+        XCTAssertFalse("a1a".isNumeric, "String containing letters and digits is not numeric")
     }
 }

--- a/Sources/String+Extensions.swift
+++ b/Sources/String+Extensions.swift
@@ -250,4 +250,13 @@ extension String {
         }
         return self.rangeOfString(string, options: [.CaseInsensitiveSearch, .DiacriticInsensitiveSearch], locale: NSLocale.currentLocale()) != nil
     }
+    
+    /**
+     - returns: Returns true if every character within the string is a numeric character.
+    */
+    func isNumeric() -> Bool {
+        return self.characters.reduce(true) {
+            $0 && String($1).rangeOfCharacterFromSet(NSCharacterSet.decimalDigitCharacterSet().invertedSet) == nil
+        }
+    }
 }

--- a/Sources/String+Extensions.swift
+++ b/Sources/String+Extensions.swift
@@ -77,6 +77,15 @@ extension String {
         let base64Decoded = NSData(base64EncodedString: self, options: []).flatMap({ String(data: $0, encoding: NSUTF8StringEncoding) })
         return base64Decoded
     }
+    
+    /**
+     Returns true if every character within the string is a numeric character. Empty strings are
+     considered non-numeric.
+    */
+    public var isNumeric: Bool {
+        guard !isEmpty else { return false }
+        return stringByTrimmingCharactersInSet(.decimalDigitCharacterSet()).isEmpty
+    }
 
     /**
      Replaces all occurences of the pattern on self in-place.
@@ -249,14 +258,5 @@ extension String {
             return localizedStandardContainsString(string)
         }
         return self.rangeOfString(string, options: [.CaseInsensitiveSearch, .DiacriticInsensitiveSearch], locale: NSLocale.currentLocale()) != nil
-    }
-    
-    /**
-     - returns: Returns true if every character within the string is a numeric character.
-    */
-    public func isNumeric() -> Bool {
-        return self.characters.reduce(true) {
-            $0 && String($1).rangeOfCharacterFromSet(NSCharacterSet.decimalDigitCharacterSet().invertedSet) == nil
-        }
     }
 }

--- a/Sources/String+Extensions.swift
+++ b/Sources/String+Extensions.swift
@@ -254,7 +254,7 @@ extension String {
     /**
      - returns: Returns true if every character within the string is a numeric character.
     */
-    func isNumeric() -> Bool {
+    public func isNumeric() -> Bool {
         return self.characters.reduce(true) {
             $0 && String($1).rangeOfCharacterFromSet(NSCharacterSet.decimalDigitCharacterSet().invertedSet) == nil
         }


### PR DESCRIPTION
A string extension to validate if every character within the string is numeric.

Usage:
```swift
if let myString = textField.text where myString.isNumeric {
  // User typed valid numeric non-empty entry
}
```