### PR TITLE
Feature/range conversion

### DIFF
--- a/AlexandriaTests/StringTests.swift
+++ b/AlexandriaTests/StringTests.swift
@@ -87,7 +87,7 @@ class StringTests: XCTestCase {
         let str = "a😜b🇬🇧c"
         let r1 = str.rangeOfString(uk)!
         
-        let n1 = str.nSRangeFromRange(r1)
+        let n1 = str.NSRangeFromRange(r1)
         XCTAssertEqual((str as NSString).substringWithRange(n1), uk, "Range should have found the UK flag")
         
         let r2 = str.rangeFromNSRange(n1)!

--- a/AlexandriaTests/StringTests.swift
+++ b/AlexandriaTests/StringTests.swift
@@ -81,4 +81,32 @@ class StringTests: XCTestCase {
         XCTAssertFalse("1a1".isNumeric, "String containing letters and digits is not numeric")
         XCTAssertFalse("a1a".isNumeric, "String containing letters and digits is not numeric")
     }
+    
+    func testExtendedStringRangeConversions() {
+        let uk = "🇬🇧"
+        let str = "a😜b🇬🇧c"
+        let r1 = str.rangeOfString(uk)!
+        
+        let n1 = str.nSRangeFromRange(r1)
+        XCTAssertEqual((str as NSString).substringWithRange(n1), uk, "Range should have found the UK flag")
+        
+        let r2 = str.rangeFromNSRange(n1)!
+        XCTAssertEqual(str.substringWithRange(r2), uk, "Range should have found the UK flag")
+    }
+    
+    func testRepeatedRangeConversion() {
+        var content: String = "This library was created by <link id=\"ovenbits\" type=\"ahref\"/> and can be found on <link id=\"github\" type=\"ahref\"/>"
+        let regexStr = "<link id=\"(.*?)\" type=\"ahref\"/>"
+        do {
+            let regex = try NSRegularExpression(pattern: regexStr, options: .CaseInsensitive)
+            for match in regex.matchesInString(content, options: NSMatchingOptions(), range: NSMakeRange(0, content.characters.count)).reverse() {
+                let reference = content.substringWithRange(content.rangeFromNSRange(match.rangeAtIndex(1))!)
+                content = content.stringByReplacingCharactersInRange(content.rangeFromNSRange(match.range)!, withString: "<a class=\"link\" href=\"http://www.\(reference).com\">\(reference)</a>")
+            }
+            XCTAssertEqual(content, "This library was created by <a class=\"link\" href=\"http://www.ovenbits.com\">ovenbits</a> and can be found on <a class=\"link\" href=\"http://www.github.com\">github</a>", "Repeated regex should have been handled")
+        } catch {
+            XCTFail("Regular expression creation issue")
+        }
+    }
+    
 }

--- a/Sources/String+Extensions.swift
+++ b/Sources/String+Extensions.swift
@@ -259,4 +259,50 @@ extension String {
         }
         return self.rangeOfString(string, options: [.CaseInsensitiveSearch, .DiacriticInsensitiveSearch], locale: NSLocale.currentLocale()) != nil
     }
+    
+    /**
+     Convert an NSRange to a Range. There is still a mismatch between the regular expression libraries
+     and NSString/String. This makes it easier to convert between the two. Using this allows complex
+     strings (including emoji, regonial indicattors, etc.) to be manipulated without having to resort
+     to NSString instances.
+     
+     Note that it may not always be possible to convert from an NSRange as they are not exactly the same.
+     
+     Taken from:
+     http://stackoverflow.com/questions/25138339/nsrange-to-rangestring-index
+     
+     - parameter nsRange: The NSRange instance to covert to a Range.
+     
+     - returns: The Range, if it was possible to convert. Otherwise nil.
+     */
+    public func rangeFromNSRange(nsRange : NSRange) -> Range<String.Index>? {
+        let from16 = utf16.startIndex.advancedBy(nsRange.location, limit: utf16.endIndex)
+        let to16 = from16.advancedBy(nsRange.length, limit: utf16.endIndex)
+        if let from = String.Index(from16, within: self),
+            let to = String.Index(to16, within: self) {
+            return from ..< to
+        }
+        return nil
+    }
+    
+    /**
+     Convert a Range to an NSRange. There is still a mismatch between the regular expression libraries
+     and NSString/String. This makes it easier to convert between the two. Using this allows complex
+     strings (including emoji, regonial indicattors, etc.) to be manipulated without having to resort
+     to NSString instances.
+     
+     Taken from:
+     http://stackoverflow.com/questions/25138339/nsrange-to-rangestring-index
+     
+     - parameter range: The Range instance to conver to an NSRange.
+     
+     - returns: The NSRange converted from the input. This will always succeed.
+     */
+    public func nSRangeFromRange(range : Range<String.Index>) -> NSRange {
+        let utf16view = self.utf16
+        let from = String.UTF16View.Index(range.startIndex, within: utf16view)
+        let to = String.UTF16View.Index(range.endIndex, within: utf16view)
+        return NSMakeRange(utf16view.startIndex.distanceTo(from), from.distanceTo(to))
+    }
+
 }

--- a/Sources/String+Extensions.swift
+++ b/Sources/String+Extensions.swift
@@ -298,7 +298,7 @@ extension String {
      
      - returns: The NSRange converted from the input. This will always succeed.
      */
-    public func nSRangeFromRange(range : Range<String.Index>) -> NSRange {
+    public func NSRangeFromRange(range : Range<String.Index>) -> NSRange {
         let utf16view = self.utf16
         let from = String.UTF16View.Index(range.startIndex, within: utf16view)
         let to = String.UTF16View.Index(range.endIndex, within: utf16view)


### PR DESCRIPTION
Sadly still necessary with half of the String/NSString APIs. Also very
useful when working in a mixed Objective-C/Swift code base.

This is based on code found on stack overflow, and credited as such. Test cases added. A little contrived, but the latter is a much reduced version of what I originally needed this solution for.