### PR TITLE
Project extractions

### DIFF
--- a/Alexandria.xcodeproj/project.pbxproj
+++ b/Alexandria.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		796510A11C6F4F2F00E01F89 /* CollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81253BDD1C69A1D00054D52C /* CollectionTests.swift */; };
 		796510A21C6F4F2F00E01F89 /* ColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81253BDF1C69A9720054D52C /* ColorTests.swift */; };
 		796510A31C6F4F2F00E01F89 /* DateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81253BE11C69B2A20054D52C /* DateTests.swift */; };
+		79B1524A1D01C5FC009E850E /* IntTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B152491D01C5FC009E850E /* IntTests.swift */; };
 		79B92E3A1C73369C0050D55B /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B92E171C73369C0050D55B /* Array+Extensions.swift */; };
 		79B92E3B1C73369C0050D55B /* CALayer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B92E181C73369C0050D55B /* CALayer+Extensions.swift */; };
 		79B92E3C1C73369C0050D55B /* CAMediaTimingFunction+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B92E191C73369C0050D55B /* CAMediaTimingFunction+Extensions.swift */; };
@@ -60,6 +61,7 @@
 
 /* Begin PBXFileReference section */
 		796510941C6F4E5C00E01F89 /* AlexandriaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AlexandriaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		79B152491D01C5FC009E850E /* IntTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntTests.swift; sourceTree = "<group>"; };
 		79B92E171C73369C0050D55B /* Array+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		79B92E181C73369C0050D55B /* CALayer+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CALayer+Extensions.swift"; sourceTree = "<group>"; };
 		79B92E191C73369C0050D55B /* CAMediaTimingFunction+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CAMediaTimingFunction+Extensions.swift"; sourceTree = "<group>"; };
@@ -223,6 +225,7 @@
 				81253BDD1C69A1D00054D52C /* CollectionTests.swift */,
 				81253BDF1C69A9720054D52C /* ColorTests.swift */,
 				81253BE11C69B2A20054D52C /* DateTests.swift */,
+				79B152491D01C5FC009E850E /* IntTests.swift */,
 				814C72041B69DD0900BB4DBD /* Supporting Files */,
 			);
 			path = AlexandriaTests;
@@ -343,6 +346,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				79B1524A1D01C5FC009E850E /* IntTests.swift in Sources */,
 				796510A31C6F4F2F00E01F89 /* DateTests.swift in Sources */,
 				796510A01C6F4F2F00E01F89 /* StringTests.swift in Sources */,
 				796510A21C6F4F2F00E01F89 /* ColorTests.swift in Sources */,

--- a/AlexandriaTests/IntTests.swift
+++ b/AlexandriaTests/IntTests.swift
@@ -1,0 +1,58 @@
+//
+//  IntTests.swift
+//
+//  Created by hsoi on 6/3/16.
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2014-2016 Oven Bits, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import XCTest
+
+class IntTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+
+    func testToAbbreviatedString() {
+        XCTAssertEqual(Int(598).toAbbreviatedString, "598")
+        XCTAssertEqual(Int(-999).toAbbreviatedString, "-999")
+        XCTAssertEqual(Int(1000).toAbbreviatedString, "1K")
+        XCTAssertEqual(Int(-1284).toAbbreviatedString, "-1.3K")
+        XCTAssertEqual(Int(9940).toAbbreviatedString, "9.9K")
+        XCTAssertEqual(Int(9980).toAbbreviatedString, "10K")
+        XCTAssertEqual(Int(39900).toAbbreviatedString, "39.9K")
+        XCTAssertEqual(Int(99880).toAbbreviatedString, "99.9K")
+        XCTAssertEqual(Int(399880).toAbbreviatedString, "0.4M")
+        XCTAssertEqual(Int(999898).toAbbreviatedString, "1M")
+        XCTAssertEqual(Int(999999).toAbbreviatedString, "1M")
+        XCTAssertEqual(Int(1456384).toAbbreviatedString, "1.5M")
+        XCTAssertEqual(Int(12383474).toAbbreviatedString, "12.4M")
+    }
+}

--- a/Sources/Int+Extensions.swift
+++ b/Sources/Int+Extensions.swift
@@ -161,7 +161,7 @@ extension Int {
      
      - author: http://stackoverflow.com/a/35504720/1737738
      */
-    func toAbbreviatedString () -> String {
+    public var toAbbreviatedString: String {
         let numFormatter = NSNumberFormatter()
         
         typealias Abbrevation = (threshold:Double, divisor:Double, suffix:String)

--- a/Sources/Int+Extensions.swift
+++ b/Sources/Int+Extensions.swift
@@ -162,27 +162,23 @@ extension Int {
      - author: http://stackoverflow.com/a/35504720/1737738
      */
     public var toAbbreviatedString: String {
-        let numFormatter = NSNumberFormatter()
-        
-        typealias Abbrevation = (threshold:Double, divisor:Double, suffix:String)
-        let abbreviations:[Abbrevation] = [(0, 1, ""),
-                                           (1000.0, 1000.0, "K"),
-                                           (100_000.0, 1_000_000.0, "M"),
-                                           (100_000_000.0, 1_000_000_000.0, "B")]
+        typealias Abbreviation = (threshold: Double, divisor: Double, suffix: String)
+        let abbreviations: [Abbreviation] = [(0, 1, ""),
+                                            (1000.0, 1000.0, "K"),
+                                            (100_000.0, 1_000_000.0, "M"),
+                                            (100_000_000.0, 1_000_000_000.0, "B")]
         // you can add more !
         
-        let startValue = Double (abs(self))
-        let abbreviation:Abbrevation = {
+        let startValue = Double(abs(self))
+        let abbreviation: Abbreviation = {
             var prevAbbreviation = abbreviations[0]
-            for tmpAbbreviation in abbreviations {
-                if (startValue < tmpAbbreviation.threshold) {
-                    break
-                }
+            for tmpAbbreviation in abbreviations where tmpAbbreviation.threshold <= startValue {
                 prevAbbreviation = tmpAbbreviation
             }
             return prevAbbreviation
-        } ()
+        }()
         
+        let numFormatter = NSNumberFormatter()
         let value = Double(self) / abbreviation.divisor
         numFormatter.positiveSuffix = abbreviation.suffix
         numFormatter.negativeSuffix = abbreviation.suffix
@@ -191,7 +187,7 @@ extension Int {
         numFormatter.minimumFractionDigits = 0
         numFormatter.maximumFractionDigits = 1
         
-        return numFormatter.stringFromNumber(NSNumber (double:value))!
+        return numFormatter.stringFromNumber(NSNumber(double: value)) ?? "\(self)"
     }
 
     

--- a/Sources/Int+Extensions.swift
+++ b/Sources/Int+Extensions.swift
@@ -138,6 +138,63 @@ extension Int {
         return String(self)
     }
     
+    
+    /**
+     Convert self to an abbreviated String.
+     
+     Examples:
+     ```
+     Value : 598 -> 598
+     Value : -999 -> -999
+     Value : 1000 -> 1K
+     Value : -1284 -> -1.3K
+     Value : 9940 -> 9.9K
+     Value : 9980 -> 10K
+     Value : 39900 -> 39.9K
+     Value : 99880 -> 99.9K
+     Value : 399880 -> 0.4M
+     Value : 999898 -> 1M
+     Value : 999999 -> 1M
+     Value : 1456384 -> 1.5M
+     Value : 12383474 -> 12.4M
+     ```
+     
+     - author: http://stackoverflow.com/a/35504720/1737738
+     */
+    func toAbbreviatedString () -> String {
+        let numFormatter = NSNumberFormatter()
+        
+        typealias Abbrevation = (threshold:Double, divisor:Double, suffix:String)
+        let abbreviations:[Abbrevation] = [(0, 1, ""),
+                                           (1000.0, 1000.0, "K"),
+                                           (100_000.0, 1_000_000.0, "M"),
+                                           (100_000_000.0, 1_000_000_000.0, "B")]
+        // you can add more !
+        
+        let startValue = Double (abs(self))
+        let abbreviation:Abbrevation = {
+            var prevAbbreviation = abbreviations[0]
+            for tmpAbbreviation in abbreviations {
+                if (startValue < tmpAbbreviation.threshold) {
+                    break
+                }
+                prevAbbreviation = tmpAbbreviation
+            }
+            return prevAbbreviation
+        } ()
+        
+        let value = Double(self) / abbreviation.divisor
+        numFormatter.positiveSuffix = abbreviation.suffix
+        numFormatter.negativeSuffix = abbreviation.suffix
+        numFormatter.allowsFloats = true
+        numFormatter.minimumIntegerDigits = 1
+        numFormatter.minimumFractionDigits = 0
+        numFormatter.maximumFractionDigits = 1
+        
+        return numFormatter.stringFromNumber(NSNumber (double:value))!
+    }
+
+    
     /**
      Repeat a block `self` times.
      

--- a/Sources/NSAttributedString+Extensions.swift
+++ b/Sources/NSAttributedString+Extensions.swift
@@ -82,9 +82,9 @@ extension NSAttributedString {
      
      - returns: A copy of `self`, with the color applied.
      */
-    public func addForeColor(color: UIColor) -> NSAttributedString {
+    public func addForegroundColor(color: UIColor) -> NSAttributedString {
         let mutableString = NSMutableAttributedString(attributedString: self)
-        mutableString.addForeColorInPlace(color)
+        mutableString.addForegroundColorInPlace(color)
         return NSAttributedString(attributedString: mutableString)
     }
     
@@ -161,7 +161,7 @@ extension NSMutableAttributedString {
      
      - parameter color: The color to apply.
      */
-    public func addForeColorInPlace(color: UIColor) {
+    public func addForegroundColorInPlace(color: UIColor) {
         self.addAttribute(NSForegroundColorAttributeName, value: color, range: NSMakeRange(0, self.length))
     }
     

--- a/Sources/NSAttributedString+Extensions.swift
+++ b/Sources/NSAttributedString+Extensions.swift
@@ -82,7 +82,7 @@ extension NSMutableAttributedString {
      
      - parameter font: The font to apply.
      */
-    public func addFontInPlace(font: UIFont) {
+    public func addFont(font: UIFont) {
         self.addAttribute(NSFontAttributeName, value: font, range: NSMakeRange(0, self.length))
     }
     
@@ -92,7 +92,7 @@ extension NSMutableAttributedString {
      
      - parameter alignment: The alignment to apply.
      */
-    public func addAlignmentInPlace(alignment: NSTextAlignment) {
+    public func addAlignment(alignment: NSTextAlignment) {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = alignment
         self.addAttribute(NSParagraphStyleAttributeName, value: paragraphStyle, range: NSMakeRange(0, self.length))
@@ -104,7 +104,7 @@ extension NSMutableAttributedString {
      
      - parameter color: The color to apply.
      */
-    public func addForegroundColorInPlace(color: UIColor) {
+    public func addForegroundColor(color: UIColor) {
         self.addAttribute(NSForegroundColorAttributeName, value: color, range: NSMakeRange(0, self.length))
     }
     
@@ -114,7 +114,7 @@ extension NSMutableAttributedString {
      
      - parameter style: The `NSUnderlineStyle` to apply. Defaults to `.StyleSingle`.
      */
-    public func addUnderlineInPlace(style: NSUnderlineStyle = .StyleSingle) {
+    public func addUnderline(style: NSUnderlineStyle = .StyleSingle) {
         self.addAttribute(NSUnderlineStyleAttributeName, value: style.rawValue, range: NSMakeRange(0, self.length))
     }
 

--- a/Sources/NSAttributedString+Extensions.swift
+++ b/Sources/NSAttributedString+Extensions.swift
@@ -45,63 +45,6 @@ extension NSAttributedString {
 }
 
 
-extension NSAttributedString {
-    
-    /**
-     Returns a copy of `self` with the given font applied.
-     
-     - parameter font: The font to apply.
-     
-     - returns: A copy of `self`, with the font applied.
-     */
-    public func addFont(font: UIFont) -> NSAttributedString {
-        let mutableString = NSMutableAttributedString(attributedString: self)
-        mutableString.addFontInPlace(font)
-        return NSAttributedString(attributedString: mutableString)
-    }
-    
-    
-    /**
-     Returns a copy of `self` with the given text alignment applied.
-     
-     - parameter alignment: The text alignment to apply.
-     
-     - returns: A copy of `self`, with the text alignment applied.
-     */
-    public func addAlignment(alignment: NSTextAlignment) -> NSAttributedString {
-        let mutableString = NSMutableAttributedString(attributedString: self)
-        mutableString.addAlignmentInPlace(alignment)
-        return NSAttributedString(attributedString: mutableString)
-    }
-    
-    
-    /**
-     Returns a copy of `self` with the given color applied as foreground color.
-     
-     - parameter color: The color to apply.
-     
-     - returns: A copy of `self`, with the color applied.
-     */
-    public func addForegroundColor(color: UIColor) -> NSAttributedString {
-        let mutableString = NSMutableAttributedString(attributedString: self)
-        mutableString.addForegroundColorInPlace(color)
-        return NSAttributedString(attributedString: mutableString)
-    }
-    
-    /**
-     Returns a copy of `self` with a single underline applied.
-     
-     - returns: A copy of `self`, underlined.
-     */
-    public func addUnderline() -> NSAttributedString {
-        let mutableString = NSMutableAttributedString(attributedString: self)
-        mutableString.addUnderlineInPlace()
-        return NSAttributedString(attributedString: mutableString)
-    }
-}
-
-
-
 extension NSMutableAttributedString {
     /**
     Modifies this instance of the string to remove characters from a given character set from

--- a/Sources/NSAttributedString+Extensions.swift
+++ b/Sources/NSAttributedString+Extensions.swift
@@ -111,9 +111,11 @@ extension NSMutableAttributedString {
     
     /**
      Applies a single underline under the whole string.
+     
+     - parameter style: The `NSUnderlineStyle` to apply. Defaults to `.StyleSingle`.
      */
-    public func addUnderlineInPlace() {
-        self.addAttribute(NSUnderlineStyleAttributeName, value: NSUnderlineStyle.StyleSingle.rawValue, range: NSMakeRange(0, self.length))
+    public func addUnderlineInPlace(style: NSUnderlineStyle = .StyleSingle) {
+        self.addAttribute(NSUnderlineStyleAttributeName, value: style.rawValue, range: NSMakeRange(0, self.length))
     }
 
 }

--- a/Sources/NSAttributedString+Extensions.swift
+++ b/Sources/NSAttributedString+Extensions.swift
@@ -44,6 +44,64 @@ extension NSAttributedString {
     }
 }
 
+
+extension NSAttributedString {
+    
+    /**
+     Returns a copy of `self` with the given font applied.
+     
+     - parameter font: The font to apply.
+     
+     - returns: A copy of `self`, with the font applied.
+     */
+    public func addFont(font: UIFont) -> NSAttributedString {
+        let mutableString = NSMutableAttributedString(attributedString: self)
+        mutableString.addFontInPlace(font)
+        return NSAttributedString(attributedString: mutableString)
+    }
+    
+    
+    /**
+     Returns a copy of `self` with the given text alignment applied.
+     
+     - parameter alignment: The text alignment to apply.
+     
+     - returns: A copy of `self`, with the text alignment applied.
+     */
+    public func addAlignment(alignment: NSTextAlignment) -> NSAttributedString {
+        let mutableString = NSMutableAttributedString(attributedString: self)
+        mutableString.addAlignmentInPlace(alignment)
+        return NSAttributedString(attributedString: mutableString)
+    }
+    
+    
+    /**
+     Returns a copy of `self` with the given color applied as foreground color.
+     
+     - parameter color: The color to apply.
+     
+     - returns: A copy of `self`, with the color applied.
+     */
+    public func addForeColor(color: UIColor) -> NSAttributedString {
+        let mutableString = NSMutableAttributedString(attributedString: self)
+        mutableString.addForeColorInPlace(color)
+        return NSAttributedString(attributedString: mutableString)
+    }
+    
+    /**
+     Returns a copy of `self` with a single underline applied.
+     
+     - returns: A copy of `self`, underlined.
+     */
+    public func addUnderline() -> NSAttributedString {
+        let mutableString = NSMutableAttributedString(attributedString: self)
+        mutableString.addUnderlineInPlace()
+        return NSAttributedString(attributedString: mutableString)
+    }
+}
+
+
+
 extension NSMutableAttributedString {
     /**
     Modifies this instance of the string to remove characters from a given character set from
@@ -70,4 +128,49 @@ extension NSMutableAttributedString {
             range = (string as NSString).rangeOfCharacterFromSet(charSet, options: .BackwardsSearch)
         }
     }
+
+}
+
+
+extension NSMutableAttributedString {
+    
+    /**
+     Applies the given font over the whole string.
+     
+     - parameter font: The font to apply.
+     */
+    public func addFontInPlace(font: UIFont) {
+        self.addAttribute(NSFontAttributeName, value: font, range: NSMakeRange(0, self.length))
+    }
+    
+    
+    /**
+     Applies the given text alignment over the whole string.
+     
+     - parameter alignment: The alignment to apply.
+     */
+    public func addAlignmentInPlace(alignment: NSTextAlignment) {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = alignment
+        self.addAttribute(NSParagraphStyleAttributeName, value: paragraphStyle, range: NSMakeRange(0, self.length))
+    }
+    
+    
+    /**
+     Applies the given color over the whole string, as the foreground color.
+     
+     - parameter color: The color to apply.
+     */
+    public func addForeColorInPlace(color: UIColor) {
+        self.addAttribute(NSForegroundColorAttributeName, value: color, range: NSMakeRange(0, self.length))
+    }
+    
+    
+    /**
+     Applies a single underline under the whole string.
+     */
+    public func addUnderlineInPlace() {
+        self.addAttribute(NSUnderlineStyleAttributeName, value: NSUnderlineStyle.StyleSingle.rawValue, range: NSMakeRange(0, self.length))
+    }
+
 }


### PR DESCRIPTION
This extracts a few useful things out of a working project to contribute here to Alexandria:

* adds `toAbbreviatedString` to `Int` extensions, as a way to get the Int as an abbreviated string (includes tests)
* Adds simple functions to extend `NSAttributedString` and `NSMutableAttributedString` 's ability to easily add font, alignment, color, and underline to the string.