### PR TITLE
UIColor enhancements

### DIFF
--- a/Alexandria.xcodeproj/project.pbxproj
+++ b/Alexandria.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		79B92E591C73369C0050D55B /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B92E381C73369C0050D55B /* UIView+Extensions.swift */; };
 		79B92E5A1C73369C0050D55B /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B92E391C73369C0050D55B /* UIViewController+Extensions.swift */; };
 		814C71FA1B69DD0900BB4DBD /* Alexandria.h in Headers */ = {isa = PBXBuildFile; fileRef = 814C71F91B69DD0900BB4DBD /* Alexandria.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81A87FD61D1828CD00F43B74 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A87FD51D1828CD00F43B74 /* Operators.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -104,6 +105,7 @@
 		814C71F91B69DD0900BB4DBD /* Alexandria.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Alexandria.h; sourceTree = "<group>"; };
 		814C72051B69DD0900BB4DBD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		814C72061B69DD0900BB4DBD /* AlexandriaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlexandriaTests.swift; sourceTree = "<group>"; };
+		81A87FD51D1828CD00F43B74 /* Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -145,6 +147,7 @@
 				79B92E261C73369C0050D55B /* NSCharacterSet+Extensions.swift */,
 				79B92E271C73369C0050D55B /* NSDate+Extensions.swift */,
 				79B92E281C73369C0050D55B /* NSObject+Extensions.swift */,
+				81A87FD51D1828CD00F43B74 /* Operators.swift */,
 				79B92E291C73369C0050D55B /* Optional+Extensions.swift */,
 				79B92E2A1C73369C0050D55B /* StoreKit */,
 				79B92E2C1C73369C0050D55B /* String+Extensions.swift */,
@@ -387,6 +390,7 @@
 				79B92E541C73369C0050D55B /* UILabel+Extensions.swift in Sources */,
 				79B92E3D1C73369C0050D55B /* CGAffineTransform+Extensions.swift in Sources */,
 				79B92E5A1C73369C0050D55B /* UIViewController+Extensions.swift in Sources */,
+				81A87FD61D1828CD00F43B74 /* Operators.swift in Sources */,
 				79B92E401C73369C0050D55B /* Comparable+Extensions.swift in Sources */,
 				79B92E531C73369C0050D55B /* UIImage+Extensions.swift in Sources */,
 				79B92E501C73369C0050D55B /* UIColor+Extensions.swift in Sources */,

--- a/Alexandria.xcodeproj/project.pbxproj
+++ b/Alexandria.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		79B92E5A1C73369C0050D55B /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B92E391C73369C0050D55B /* UIViewController+Extensions.swift */; };
 		814C71FA1B69DD0900BB4DBD /* Alexandria.h in Headers */ = {isa = PBXBuildFile; fileRef = 814C71F91B69DD0900BB4DBD /* Alexandria.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81A87FD61D1828CD00F43B74 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A87FD51D1828CD00F43B74 /* Operators.swift */; };
+		81A87FD81D182E0800F43B74 /* CGFloatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A87FD71D182E0800F43B74 /* CGFloatTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -106,6 +107,7 @@
 		814C72051B69DD0900BB4DBD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		814C72061B69DD0900BB4DBD /* AlexandriaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlexandriaTests.swift; sourceTree = "<group>"; };
 		81A87FD51D1828CD00F43B74 /* Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
+		81A87FD71D182E0800F43B74 /* CGFloatTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGFloatTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -229,6 +231,7 @@
 				81253BDF1C69A9720054D52C /* ColorTests.swift */,
 				81253BE11C69B2A20054D52C /* DateTests.swift */,
 				79B152491D01C5FC009E850E /* IntTests.swift */,
+				81A87FD71D182E0800F43B74 /* CGFloatTests.swift */,
 				814C72041B69DD0900BB4DBD /* Supporting Files */,
 			);
 			path = AlexandriaTests;
@@ -353,6 +356,7 @@
 				796510A31C6F4F2F00E01F89 /* DateTests.swift in Sources */,
 				796510A01C6F4F2F00E01F89 /* StringTests.swift in Sources */,
 				796510A21C6F4F2F00E01F89 /* ColorTests.swift in Sources */,
+				81A87FD81D182E0800F43B74 /* CGFloatTests.swift in Sources */,
 				796510A11C6F4F2F00E01F89 /* CollectionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Alexandria/Info.plist
+++ b/Alexandria/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AlexandriaTests/CGFloatTests.swift
+++ b/AlexandriaTests/CGFloatTests.swift
@@ -1,0 +1,24 @@
+//
+//  CGFloatTests.swift
+//  Alexandria
+//
+//  Created by Jonathan Landon on 6/20/16.
+//
+//
+
+import XCTest
+
+class CGFloatTests: XCTestCase {
+
+    func testRounded() {
+        XCTAssertEqual((1.234567 as CGFloat).rounded(places: 0), 1)
+        XCTAssertEqual((1.234567 as CGFloat).rounded(places: 1), 1.2)
+        XCTAssertEqual((1.234567 as CGFloat).rounded(places: 2), 1.23)
+        XCTAssertEqual((1.234567 as CGFloat).rounded(places: 3), 1.235)
+        XCTAssertEqual((1.234567 as CGFloat).rounded(places: 4), 1.2346)
+        XCTAssertEqual((1.234567 as CGFloat).rounded(places: 5), 1.23457)
+        XCTAssertEqual((1.234567 as CGFloat).rounded(places: 6), 1.234567)
+        XCTAssertEqual((1.234567 as CGFloat).rounded(places: 7), 1.234567)
+    }
+
+}

--- a/AlexandriaTests/ColorTests.swift
+++ b/AlexandriaTests/ColorTests.swift
@@ -26,6 +26,7 @@
 // SOFTWARE.
 
 import XCTest
+import Alexandria
 
 class ColorTests: XCTestCase {
 
@@ -43,6 +44,8 @@ class ColorTests: XCTestCase {
         XCTAssertEqual(UIColor(hex: 0xFF0000), UIColor.redColor(), "Colors not equal")
         XCTAssertEqual(UIColor(hexString: "#00FF00"), UIColor.greenColor(), "Colors not equal")
         XCTAssertEqual(UIColor(hexString: "0000FF"), UIColor.blueColor(), "Colors not equal")
+        XCTAssertEqual(UIColor(hue: 0, saturation: 1, lightness: 0.5), UIColor.redColor(), "Colors not equal")
+        XCTAssertEqual(UIColor(cyan: 0, magenta: 1, yellow: 1, key: 0), UIColor.redColor(), "Colors not equal")
     }
     
     func testHexString() {
@@ -56,8 +59,257 @@ class ColorTests: XCTestCase {
     func testComponents() {
         let color = UIColor(hex: 0xEF5138)
         
-        XCTAssertEqual(String(format: "%.3f", color.redComponent), "0.937", "Red components are not equal")
-        XCTAssertEqual(String(format: "%.3f", color.greenComponent), "0.318", "Green components are not equal")
-        XCTAssertEqual(String(format: "%.3f", color.blueComponent), "0.220", "Blue components are not equal")
+        XCTAssertCGFloatEqual(color.rgba.r, 0.937, roundedToDecimalPlaces: 3, "Red components are not equal")
+        XCTAssertCGFloatEqual(color.rgba.g, 0.318, roundedToDecimalPlaces: 3, "Green components are not equal")
+        XCTAssertCGFloatEqual(color.rgba.b, 0.220, roundedToDecimalPlaces: 3, "Blue components are not equal")
     }
+    
+    func testLightenColor() {
+        let color = UIColor(hex: 0xEF5138)
+        XCTAssertEqual(color.lighten(by: 0.2).hex, 0xF3816F)
+        XCTAssertEqual(color.lighten(by: 20%).hex, 0xF3816F)
+    }
+    
+    func testDarkenColor() {
+        let color = UIColor(hex: 0xEF5138)
+        XCTAssertEqual(color.darken(by: 0.2).hex, 0xDA2D12)
+        XCTAssertEqual(color.darken(by: 20%).hex, 0xDA2D12)
+    }
+    
+    func testRGBColorModel() {
+        let rgb: [(r: CGFloat, g: CGFloat, b: CGFloat)] = [
+            (255, 255, 0),
+            (255, 128, 0),
+            (255, 0, 0),
+            (0, 255, 0),
+            (0, 128, 0),
+            (0, 255, 255),
+            (0, 0, 255),
+            (170, 0, 255),
+            (255, 0, 255),
+            (153, 102, 0),
+            (255, 255, 255),
+            (242, 242, 242),
+            (179, 179, 179),
+            (102, 102, 102),
+            (0, 0, 0),
+        ]
+        
+        for color in rgb {
+            let model = UIColor.Model.rgb(color.r, color.g, color.b)
+            
+            let hsl  = UIColor.Model.hsl(model.hsl.h, model.hsl.s, model.hsl.l)
+            let hsb  = UIColor.Model.hsb(model.hsb.h, model.hsb.s, model.hsb.b)
+            let cmyk = UIColor.Model.cmyk(model.cmyk.c, model.cmyk.m, model.cmyk.y, model.cmyk.k)
+            let hex  = UIColor.Model.hex(model.hex)
+            
+            XCTAssertEqual(hsl.rgb.r, color.r)
+            XCTAssertEqual(hsl.rgb.g, color.g)
+            XCTAssertEqual(hsl.rgb.b, color.b)
+            
+            XCTAssertEqual(hsb.rgb.r, color.r)
+            XCTAssertEqual(hsb.rgb.g, color.g)
+            XCTAssertEqual(hsb.rgb.b, color.b)
+            
+            XCTAssertEqual(cmyk.rgb.r, color.r)
+            XCTAssertEqual(cmyk.rgb.g, color.g)
+            XCTAssertEqual(cmyk.rgb.b, color.b)
+            
+            XCTAssertEqual(hex.rgb.r, color.r)
+            XCTAssertEqual(hex.rgb.g, color.g)
+            XCTAssertEqual(hex.rgb.b, color.b)
+        }
+    }
+    
+    func testhsbColorModel() {
+        let hsb: [(h: CGFloat, s: CGFloat, b: CGFloat)] = [
+            (60/360, 1, 1),
+            (30/360, 1, 1),
+            (0, 1, 1),
+            (120/360, 1, 1),
+            (120/360, 1, 0.5),
+            (180/360, 1, 1),
+            (240/360, 1, 1),
+            (280/360, 1, 1),
+            (300/360, 1, 1),
+            (40/360, 1, 0.6),
+            (0, 0, 1),
+            (0, 0, 0.95),
+            (0, 0, 0.7),
+            (0, 0, 0.4),
+            (0, 0, 0),
+        ]
+        
+        for color in hsb {
+            let model = UIColor.Model.hsb(color.h, color.s, color.b)
+            
+            let rgb  = UIColor.Model.rgb(model.rgb.r, model.rgb.g, model.rgb.b)
+            let hsb  = UIColor.Model.hsb(model.hsb.h, model.hsb.s, model.hsb.b)
+            let cmyk = UIColor.Model.cmyk(model.cmyk.c, model.cmyk.m, model.cmyk.y, model.cmyk.k)
+            let hex  = UIColor.Model.hex(model.hex)
+            
+            XCTAssertCGFloatEqual(rgb.hsb.h, color.h, roundedToDecimalPlaces: 2, "Hue components are not equal")
+            XCTAssertCGFloatEqual(rgb.hsb.s, color.s, roundedToDecimalPlaces: 2, "Saturation components are not equal")
+            XCTAssertCGFloatEqual(rgb.hsb.b, color.b, roundedToDecimalPlaces: 2, "Brightness components are not equal")
+            
+            XCTAssertCGFloatEqual(hsb.hsb.h, color.h, roundedToDecimalPlaces: 2, "Hue components are not equal")
+            XCTAssertCGFloatEqual(hsb.hsb.s, color.s, roundedToDecimalPlaces: 2, "Saturation components are not equal")
+            XCTAssertCGFloatEqual(hsb.hsb.b, color.b, roundedToDecimalPlaces: 2, "Brightness components are not equal")
+            
+            XCTAssertCGFloatEqual(cmyk.hsb.h, color.h, roundedToDecimalPlaces: 2, "Hue components are not equal")
+            XCTAssertCGFloatEqual(cmyk.hsb.s, color.s, roundedToDecimalPlaces: 2, "Saturation components are not equal")
+            XCTAssertCGFloatEqual(cmyk.hsb.b, color.b, roundedToDecimalPlaces: 2, "Brightness components are not equal")
+            
+            XCTAssertCGFloatEqual(hex.hsb.h, color.h, roundedToDecimalPlaces: 2, "Hue components are not equal")
+            XCTAssertCGFloatEqual(hex.hsb.s, color.s, roundedToDecimalPlaces: 2, "Saturation components are not equal")
+            XCTAssertCGFloatEqual(hex.hsb.b, color.b, roundedToDecimalPlaces: 2, "Brightness components are not equal")
+        }
+    }
+    
+    func testHSLColorModel() {
+        let hsl: [(h: CGFloat, s: CGFloat, l: CGFloat)] = [
+            (60/360, 1, 0.5),
+            (30/360, 1, 0.5),
+            (0, 1, 0.5),
+            (120/360, 1, 0.5),
+            (120/360, 1, 0.25),
+            (180/360, 1, 0.5),
+            (240/360, 1, 0.5),
+            (280/360, 1, 0.5),
+            (300/360, 1, 0.5),
+            (40/360, 1, 0.3),
+            (0, 0, 1),
+            (0, 0, 0.95),
+            (0, 0, 0.7),
+            (0, 0, 0.4),
+            (0, 0, 0),
+        ]
+        
+        for color in hsl {
+            let model = UIColor.Model.hsl(color.h, color.s, color.l)
+            
+            let rgb  = UIColor.Model.rgb(model.rgb.r, model.rgb.g, model.rgb.b)
+            let hsb  = UIColor.Model.hsb(model.hsb.h, model.hsb.s, model.hsb.b)
+            let cmyk = UIColor.Model.cmyk(model.cmyk.c, model.cmyk.m, model.cmyk.y, model.cmyk.k)
+            let hex  = UIColor.Model.hex(model.hex)
+            
+            XCTAssertCGFloatEqual(rgb.hsl.h, color.h, roundedToDecimalPlaces: 2, "Hue components are not equal")
+            XCTAssertCGFloatEqual(rgb.hsl.s, color.s, roundedToDecimalPlaces: 2, "Saturation components are not equal")
+            XCTAssertCGFloatEqual(rgb.hsl.l, color.l, roundedToDecimalPlaces: 2, "Lightness components are not equal")
+            
+            XCTAssertCGFloatEqual(hsb.hsl.h, color.h, roundedToDecimalPlaces: 2, "Hue components are not equal")
+            XCTAssertCGFloatEqual(hsb.hsl.s, color.s, roundedToDecimalPlaces: 2, "Saturation components are not equal")
+            XCTAssertCGFloatEqual(hsb.hsl.l, color.l, roundedToDecimalPlaces: 2, "Lightness components are not equal")
+            
+            XCTAssertCGFloatEqual(cmyk.hsl.h, color.h, roundedToDecimalPlaces: 2, "Hue components are not equal")
+            XCTAssertCGFloatEqual(cmyk.hsl.s, color.s, roundedToDecimalPlaces: 2, "Saturation components are not equal")
+            XCTAssertCGFloatEqual(cmyk.hsl.l, color.l, roundedToDecimalPlaces: 2, "Lightness components are not equal")
+            
+            XCTAssertCGFloatEqual(hex.hsl.h, color.h, roundedToDecimalPlaces: 2, "Hue components are not equal")
+            XCTAssertCGFloatEqual(hex.hsl.s, color.s, roundedToDecimalPlaces: 2, "Saturation components are not equal")
+            XCTAssertCGFloatEqual(hex.hsl.l, color.l, roundedToDecimalPlaces: 2, "Lightness components are not equal")
+        }
+    }
+    
+    func testCMYKColorModel() {
+        let cmyk: [(c: CGFloat, m: CGFloat, y: CGFloat, k: CGFloat)] = [
+            (0, 0, 1, 0),
+            (0, 0.5, 1, 0),
+            (0, 1, 1, 0),
+            (1, 0, 1, 0),
+            (1, 0, 1, 0.5),
+            (1, 0, 0, 0),
+            (1, 1, 0, 0),
+            (1/3, 1, 0, 0),
+            (0, 1, 0, 0),
+            (0, 1/3, 1, 0.4),
+            (0, 0, 0, 0),
+            (0, 0, 0, 0.05),
+            (0, 0, 0, 0.3),
+            (0, 0, 0, 0.6),
+            (0, 0, 0, 1),
+        ]
+        
+        for color in cmyk {
+            let model = UIColor.Model.cmyk(color.c, color.m, color.y, color.k)
+            
+            let rgb  = UIColor.Model.rgb(model.rgb.r, model.rgb.g, model.rgb.b)
+            let hsl  = UIColor.Model.hsl(model.hsl.h, model.hsl.s, model.hsl.l)
+            let hsb  = UIColor.Model.hsb(model.hsb.h, model.hsb.s, model.hsb.b)
+            let hex  = UIColor.Model.hex(model.hex)
+            
+            XCTAssertCGFloatEqual(rgb.cmyk.c, color.c, roundedToDecimalPlaces: 2, "Cyan components are not equal")
+            XCTAssertCGFloatEqual(rgb.cmyk.m, color.m, roundedToDecimalPlaces: 2, "Magenta components are not equal")
+            XCTAssertCGFloatEqual(rgb.cmyk.y, color.y, roundedToDecimalPlaces: 2, "Yellow components are not equal")
+            XCTAssertCGFloatEqual(rgb.cmyk.k, color.k, roundedToDecimalPlaces: 2, "Key components are not equal")
+            
+            XCTAssertCGFloatEqual(hsl.cmyk.c, color.c, roundedToDecimalPlaces: 2, "Cyan components are not equal")
+            XCTAssertCGFloatEqual(hsl.cmyk.m, color.m, roundedToDecimalPlaces: 2, "Magenta components are not equal")
+            XCTAssertCGFloatEqual(hsl.cmyk.y, color.y, roundedToDecimalPlaces: 2, "Yellow components are not equal")
+            XCTAssertCGFloatEqual(hsl.cmyk.k, color.k, roundedToDecimalPlaces: 2, "Key components are not equal")
+            
+            XCTAssertCGFloatEqual(hsb.cmyk.c, color.c, roundedToDecimalPlaces: 2, "Cyan components are not equal")
+            XCTAssertCGFloatEqual(hsb.cmyk.m, color.m, roundedToDecimalPlaces: 2, "Magenta components are not equal")
+            XCTAssertCGFloatEqual(hsb.cmyk.y, color.y, roundedToDecimalPlaces: 2, "Yellow components are not equal")
+            XCTAssertCGFloatEqual(hsb.cmyk.k, color.k, roundedToDecimalPlaces: 2, "Key components are not equal")
+            
+            XCTAssertCGFloatEqual(hex.cmyk.c, color.c, roundedToDecimalPlaces: 2, "Cyan components are not equal")
+            XCTAssertCGFloatEqual(hex.cmyk.m, color.m, roundedToDecimalPlaces: 2, "Magenta components are not equal")
+            XCTAssertCGFloatEqual(hex.cmyk.y, color.y, roundedToDecimalPlaces: 2, "Yellow components are not equal")
+            XCTAssertCGFloatEqual(hex.cmyk.k, color.k, roundedToDecimalPlaces: 2, "Key components are not equal")
+        }
+    }
+    
+    func testHexColorModel() {
+        let hex: [UInt32] = [
+            0xFFFF00,
+            0xFF8000,
+            0xFF0000,
+            0x00FF00,
+            0x008000,
+            0x00FFFF,
+            0x0000FF,
+            0xAA00FF,
+            0xFF00FF,
+            0x996600,
+            0xFFFFFF,
+            0xF3F3F3,
+            0xB3B3B3,
+            0x676767,
+            0x000000
+        ]
+        
+        for color in hex {
+            let model = UIColor.Model.hex(color)
+            
+            let rgb  = UIColor.Model.rgb(model.rgb.r, model.rgb.g, model.rgb.b)
+            let hsl  = UIColor.Model.hsl(model.hsl.h, model.hsl.s, model.hsl.l)
+            let hsb  = UIColor.Model.hsb(model.hsb.h, model.hsb.s, model.hsb.b)
+            let cmyk = UIColor.Model.cmyk(model.cmyk.c, model.cmyk.m, model.cmyk.y, model.cmyk.k)
+            
+            XCTAssertEqual(rgb.hex, color)
+            XCTAssertEqual(rgb.hex, color)
+            XCTAssertEqual(rgb.hex, color)
+            XCTAssertEqual(rgb.hex, color)
+            
+            XCTAssertEqual(hsl.hex, color)
+            XCTAssertEqual(hsl.hex, color)
+            XCTAssertEqual(hsl.hex, color)
+            XCTAssertEqual(hsl.hex, color)
+            
+            XCTAssertEqual(hsb.hex, color)
+            XCTAssertEqual(hsb.hex, color)
+            XCTAssertEqual(hsb.hex, color)
+            XCTAssertEqual(hsb.hex, color)
+            
+            XCTAssertEqual(cmyk.hex, color)
+            XCTAssertEqual(cmyk.hex, color)
+            XCTAssertEqual(cmyk.hex, color)
+            XCTAssertEqual(cmyk.hex, color)
+        }
+    }
+}
+
+func XCTAssertCGFloatEqual(lhs: CGFloat, _ rhs: CGFloat, roundedToDecimalPlaces places: UInt, _ message: String) {
+    XCTAssertEqual(lhs.rounded(places: places), rhs.rounded(places: places), message)
 }

--- a/Sources/CGFloat+Extensions.swift
+++ b/Sources/CGFloat+Extensions.swift
@@ -54,6 +54,6 @@ extension CGFloat {
      */
     public func rounded(places places: UInt) -> CGFloat {
         let multiplier = pow(10, CGFloat(places))
-        return CoreGraphics.round(self * multiplier) / multiplier
+        return round(self * multiplier) / multiplier
     }
 }

--- a/Sources/CGFloat+Extensions.swift
+++ b/Sources/CGFloat+Extensions.swift
@@ -37,4 +37,23 @@ extension CGFloat {
     public static func random(min min: CGFloat, max: CGFloat) -> CGFloat {
         return random(min...max)
     }
+    
+    /**
+     Round self to a specified number of decimal places.
+     
+     - parameter places: The number of decimal places by which to round self.
+     - returns: A CGFloat value, rounded to the specified number of decimal places.
+     
+     Examples:
+     ```
+     let val: CGFloat = 12.345678
+     
+     val.rounded(places: 2) // 12.35
+     val.rounded(places: 3) // 12.346
+     ```
+     */
+    public func rounded(places places: UInt) -> CGFloat {
+        let multiplier = pow(10, CGFloat(places))
+        return CoreGraphics.round(self * multiplier) / multiplier
+    }
 }

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -1,0 +1,21 @@
+//
+//  Operators.swift
+//  Alexandria
+//
+//  Created by Jonathan Landon on 6/20/16.
+//
+//
+
+postfix operator % {}
+
+public postfix func %(value: CGFloat) -> CGFloat {
+    return value / 100
+}
+
+public postfix func %(value: Float) -> Float {
+    return value / 100
+}
+
+public postfix func %(value: Double) -> Double {
+    return value / 100
+}

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -1,10 +1,29 @@
 //
 //  Operators.swift
-//  Alexandria
 //
 //  Created by Jonathan Landon on 6/20/16.
 //
+// The MIT License (MIT)
 //
+// Copyright (c) 2014-2016 Oven Bits, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 postfix operator % {}
 

--- a/Sources/UIColor+Extensions.swift
+++ b/Sources/UIColor+Extensions.swift
@@ -112,20 +112,15 @@ extension UIColor {
      - returns: A UInt32 that represents the hexadecimal color.
      */
     public final var hex: UInt32 {
-        let rgba = RGBAComponents
-        
-        let red   = (UInt32)(rgba.r * 255) << 16
-        let green = (UInt32)(rgba.g * 255) << 8
-        let blue  = (UInt32)(rgba.b * 255)
-        
-        return red | green | blue
+        let (r, g, b, _) = self.rgba
+        return Model.rgb(r * 255, g * 255, b * 255).hex
     }
     
     /**
      Returns the RGBA (red, green, blue, alpha) components.
      - returns: The RGBA components as a tuple (r, g, b, a).
      */
-    public final var RGBAComponents: (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
+    public final var rgba: (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
         var (r, g, b, a): (CGFloat, CGFloat, CGFloat, CGFloat) = (0, 0, 0, 0)
         getRed(&r, green: &g, blue: &b, alpha: &a)
             
@@ -133,35 +128,30 @@ extension UIColor {
     }
     
     /**
-     Returns the red component.
-     - returns: The red component as a CGFloat.
+     Returns the HSL (hue, saturation, lightness) components.
+     - returns: The HSL components as a tuple (h, s, l).
      */
-    public final var redComponent: CGFloat {
-        return RGBAComponents.r
+    public final var hsl: (h: CGFloat, s: CGFloat, l: CGFloat) {
+        let (r, g, b, _) = rgba
+        return Model.rgb(r * 255, g * 255, b * 255).hsl
     }
     
     /**
-     Returns the green component.
-     - returns: The green component as a CGFloat.
+     Returns the HSB (hue, saturation, brightness) components.
+     - returns: The HSB components as a tuple (h, s, b).
      */
-    public final var greenComponent: CGFloat {
-        return RGBAComponents.g
+    public final var hsb: (h: CGFloat, s: CGFloat, b: CGFloat) {
+        let (r, g, b, _) = rgba
+        return Model.rgb(r * 255, g * 255, b * 255).hsb
     }
     
     /**
-     Returns the blue component.
-     - returns: The blue component as a CGFloat.
+     Returns the CMYK (cyan, magenta, yellow, key) components.
+     - returns: The CMYK components as a tuple (c, m, y, k).
      */
-    public final var blueComponent: CGFloat {
-        return RGBAComponents.b
-    }
-    
-    /**
-     Returns the alpha component.
-     - returns: The alpha component as a CGFloat.
-     */
-    public final var alphaComponent: CGFloat {
-        return RGBAComponents.a
+    public final var cmyk: (c: CGFloat, m: CGFloat, y: CGFloat, k: CGFloat) {
+        let (r, g, b, _) = rgba
+        return Model.rgb(r * 255, g * 255, b * 255).cmyk
     }
     
     /**

--- a/Sources/UIColor+Extensions.swift
+++ b/Sources/UIColor+Extensions.swift
@@ -36,6 +36,9 @@ extension UIColor {
      - returns: A UIColor initialized with the given color value.
      */
     public convenience init(hex: UInt32, alpha: CGFloat = 1) {
+        assert((0...0xFFFFFF).contains(hex), "hex must be a value between 0x000000 and 0xFFFFFF")
+        assert((0...1).contains(alpha), "alpha must be a value between 0.0 and 1.0")
+        
         let (r, g, b) = Model.hex(hex).rgb
         self.init(red: r/255, green: g/255, blue: b/255, alpha: alpha)
     }
@@ -49,6 +52,11 @@ extension UIColor {
      - returns: A UIColor initialized with the given color value.
      */
     public convenience init(hue: CGFloat, saturation: CGFloat, lightness: CGFloat, alpha: CGFloat = 1) {
+        assert((0...1).contains(hue), "hue value must be a value between 0.0 and 1.0")
+        assert((0...1).contains(saturation), "saturation must be a value between 0.0 and 1.0")
+        assert((0...1).contains(lightness), "lightness must be a value between 0.0 and 1.0")
+        assert((0...1).contains(alpha), "alpha must be a value between 0.0 and 1.0")
+        
         let (r, g, b) = Model.hsl(hue, saturation, lightness).rgb
         self.init(red: r/255, green: g/255, blue: b/255, alpha: alpha)
     }
@@ -63,14 +71,20 @@ extension UIColor {
      - returns: A UIColor initialized with the given color value.
      */
     public convenience init(cyan: CGFloat, magenta: CGFloat, yellow: CGFloat, key: CGFloat, alpha: CGFloat = 1) {
+        assert((0...1).contains(cyan), "cyan value must be a value between 0.0 and 1.0")
+        assert((0...1).contains(magenta), "magenta must be a value between 0.0 and 1.0")
+        assert((0...1).contains(yellow), "yellow must be a value between 0.0 and 1.0")
+        assert((0...1).contains(key), "key must be a value between 0.0 and 1.0")
+        assert((0...1).contains(alpha), "alpha must be a value between 0.0 and 1.0")
+        
         let (r, g, b) = Model.cmyk(cyan, magenta, yellow, key).rgb
         self.init(red: r/255, green: g/255, blue: b/255, alpha: alpha)
     }
     
     /**
      Returns a UIColor from a given hex color string.
-     - parameter hexString: The hex color string, e.g.: "#9443FB" or "9443FB". The leading "#" is recommended but optional.
-     - returns: A UIColor initialized with the color specified by the hexString. In the event of an invalid hexString, including nil, it will attempt to return some sort of valid UIColor (perhaps black) but may return nil; all depends on the particulars of the given string.
+     - parameter hexString: The hex color string, e.g.: "#9443FB" or "9443FB".
+     - returns: A UIColor initialized with the color specified by the hexString.
      */
     public convenience init(hexString: String, alpha: CGFloat = 1) {
         var hexString = hexString
@@ -79,7 +93,10 @@ extension UIColor {
         }
         let scanner = NSScanner(string: hexString)
         var hexEquivalent: UInt32 = 0
-        scanner.scanHexInt(&hexEquivalent)
+        
+        if !scanner.scanHexInt(&hexEquivalent) {
+            assertionFailure("hexString did not contain a valid hex value")
+        }
         
         self.init(hex: hexEquivalent, alpha: alpha)
     }
@@ -106,7 +123,7 @@ extension UIColor {
      - returns: The lightened color.
      */
     public final func lighten(by amount: CGFloat) -> UIColor {
-        assert(amount >= 0 && amount <= 1, "Percentage must be in range 0-100%")
+        assert((0...1).contains(amount), "amount must be in range 0-100%")
         
         let (h, s, l) = hsl
         return UIColor(hue: h, saturation: s, lightness: l * (1 + amount), alpha: rgba.a)
@@ -118,7 +135,7 @@ extension UIColor {
      - returns: The darkened color.
      */
     public final func darken(by amount: CGFloat) -> UIColor {
-        assert(amount >= 0 && amount <= 1, "Percentage must be in range 0-100%")
+        assert((0...1).contains(amount), "amount must be in range 0-100%")
         
         let (h, s, l) = hsl
         return UIColor(hue: h, saturation: s, lightness: l * (1 - amount), alpha: rgba.a)
@@ -143,7 +160,7 @@ extension UIColor {
     }
     
     /**
-     Returns the RGBA (red, green, blue, alpha) components.
+     Returns the RGBA (red, green, blue, alpha) components, specified as values from 0.0 to 1.0.
      - returns: The RGBA components as a tuple (r, g, b, a).
      */
     public final var rgba: (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
@@ -154,7 +171,7 @@ extension UIColor {
     }
     
     /**
-     Returns the HSL (hue, saturation, lightness) components.
+     Returns the HSL (hue, saturation, lightness) components, specified as values from 0.0 to 1.0.
      - returns: The HSL components as a tuple (h, s, l).
      */
     public final var hsl: (h: CGFloat, s: CGFloat, l: CGFloat) {
@@ -163,7 +180,7 @@ extension UIColor {
     }
     
     /**
-     Returns the HSB (hue, saturation, brightness) components.
+     Returns the HSB (hue, saturation, brightness) components, specified as values from 0.0 to 1.0.
      - returns: The HSB components as a tuple (h, s, b).
      */
     public final var hsb: (h: CGFloat, s: CGFloat, b: CGFloat) {
@@ -172,7 +189,7 @@ extension UIColor {
     }
     
     /**
-     Returns the CMYK (cyan, magenta, yellow, key) components.
+     Returns the CMYK (cyan, magenta, yellow, key) components, specified as values from 0.0 to 1.0.
      - returns: The CMYK components as a tuple (c, m, y, k).
      */
     public final var cmyk: (c: CGFloat, m: CGFloat, y: CGFloat, k: CGFloat) {
@@ -219,7 +236,6 @@ extension UIColor {
     /**
      Model is an enum for describing and converting color models.
      
-     Given an hour, minute, and second, the time will be formatted in one of four formats.
      - `rgb`: Red, Green, Blue color representation
      - `hsl`: Hue, Saturation, Lightness color representation
      - `hsb`: Hue, Saturation, Brightness color representation
@@ -479,7 +495,7 @@ extension UIColor {
      - parameter amount: The percentage to lighten the color by. Valid values are from 0.0 to 1.0.
      - returns: The lightened color.
      */
-    @available(*, deprecated=1.0.0, message="use 'lighten(by:)'")
+    @available(*, deprecated=1.2.0, message="use 'lighten(by:)'")
     public final func lighterColorByPercentage(amount: CGFloat) -> UIColor {
         var hue: CGFloat = 1.0
         var saturation: CGFloat = 1.0
@@ -496,7 +512,7 @@ extension UIColor {
      - parameter amount: The percentage to darken the color by. Valid values are from 0.0 to 1.0.
      - returns: The darkened color.
      */
-    @available(*, deprecated=1.0.0, message="use 'darken(by:)'")
+    @available(*, deprecated=1.2.0, message="use 'darken(by:)'")
     public final func darkerColorByPercentage(amount: CGFloat) -> UIColor {
         var hue: CGFloat = 1.0
         var saturation: CGFloat = 1.0
@@ -521,7 +537,7 @@ extension UIColor {
      Returns the red component.
      - returns: The red component as a CGFloat.
      */
-    @available(*, deprecated=1.0.0, message="use 'rgba.r'")
+    @available(*, deprecated=1.2.0, message="use 'rgba.r'")
     public final var redComponent: CGFloat {
         return rgba.r
     }
@@ -530,7 +546,7 @@ extension UIColor {
      Returns the green component.
      - returns: The green component as a CGFloat.
      */
-    @available(*, deprecated=1.0.0, message="use 'rgba.g'")
+    @available(*, deprecated=1.2.0, message="use 'rgba.g'")
     public final var greenComponent: CGFloat {
         return rgba.g
     }
@@ -539,7 +555,7 @@ extension UIColor {
      Returns the blue component.
      - returns: The blue component as a CGFloat.
      */
-    @available(*, deprecated=1.0.0, message="use 'rgba.b'")
+    @available(*, deprecated=1.2.0, message="use 'rgba.b'")
     public final var blueComponent: CGFloat {
         return rgba.b
     }
@@ -548,7 +564,7 @@ extension UIColor {
      Returns the alpha component.
      - returns: The alpha component as a CGFloat.
      */
-    @available(*, deprecated=1.0.0, message="use 'rgba.a'")
+    @available(*, deprecated=1.2.0, message="use 'rgba.a'")
     public final var alphaComponent: CGFloat {
         return rgba.a
     }

--- a/Sources/UIColor+Extensions.swift
+++ b/Sources/UIColor+Extensions.swift
@@ -215,20 +215,6 @@ extension UIColor {
     }
 }
 
-postfix operator % {}
-
-public postfix func %(value: CGFloat) -> CGFloat {
-    return value / 100
-}
-
-public postfix func %(value: Float) -> Float {
-    return value / 100
-}
-
-public postfix func %(value: Double) -> Double {
-    return value / 100
-}
-
 // MARK: - Model
 
 extension UIColor {

--- a/Sources/UIColor+Extensions.swift
+++ b/Sources/UIColor+Extensions.swift
@@ -31,14 +31,40 @@ extension UIColor {
     
     /**
      Returns a UIColor from the given hexidecimal integer.
-     - parameter hex: The color value.
+     - parameter hex: The hex component of the color object, specified as a value from 0x000000 to 0xFFFFFF.
+     - parameter alpha: The opacity component of the color object, specified as a value from 0.0 to 1.0 (optional).
      - returns: A UIColor initialized with the given color value.
      */
-    public convenience init(hex: UInt32) {
-        let r = (hex >> 16) & 0xFF
-        let g = (hex >> 8) & 0xFF
-        let b = hex & 0xFF
-        self.init(red: CGFloat(r)/255.0, green: CGFloat(g)/255.0, blue: CGFloat(b)/255.0, alpha: 1.0)
+    public convenience init(hex: UInt32, alpha: CGFloat = 1) {
+        let (r, g, b) = Model.hex(hex).rgb
+        self.init(red: r/255, green: g/255, blue: b/255, alpha: alpha)
+    }
+    
+    /**
+     Returns a UIColor from a hue-saturation-lightness (HSL) set.
+     - parameter hue: The hue component of the color object, specified as a value from 0.0 to 1.0.
+     - parameter saturation: The saturation component of the color object, specified as a value from 0.0 to 1.0.
+     - parameter lightness: The lightness component of the color object, specified as a value from 0.0 to 1.0.
+     - parameter alpha: The opacity component of the color object, specified as a value from 0.0 to 1.0 (optional).
+     - returns: A UIColor initialized with the given color value.
+     */
+    public convenience init(hue: CGFloat, saturation: CGFloat, lightness: CGFloat, alpha: CGFloat = 1) {
+        let (r, g, b) = Model.hsl(hue, saturation, lightness).rgb
+        self.init(red: r/255, green: g/255, blue: b/255, alpha: alpha)
+    }
+    
+    /**
+     Returns a UIColor from a cyan-magenta-yellow-key (CMYK) set.
+     - parameter cyan: The cyan component of the color object, specified as a value from 0.0 to 1.0.
+     - parameter magenta: The magenta component of the color object, specified as a value from 0.0 to 1.0.
+     - parameter yellow: The yellow component of the color object, specified as a value from 0.0 to 1.0.
+     - parameter key: The key (black) component of the color object, specified as a value from 0.0 to 1.0.
+     - parameter alpha: The opacity component of the color object, specified as a value from 0.0 to 1.0 (optional).
+     - returns: A UIColor initialized with the given color value.
+     */
+    public convenience init(cyan: CGFloat, magenta: CGFloat, yellow: CGFloat, key: CGFloat, alpha: CGFloat = 1) {
+        let (r, g, b) = Model.cmyk(cyan, magenta, yellow, key).rgb
+        self.init(red: r/255, green: g/255, blue: b/255, alpha: alpha)
     }
     
     /**
@@ -46,16 +72,16 @@ extension UIColor {
      - parameter hexString: The hex color string, e.g.: "#9443FB" or "9443FB". The leading "#" is recommended but optional.
      - returns: A UIColor initialized with the color specified by the hexString. In the event of an invalid hexString, including nil, it will attempt to return some sort of valid UIColor (perhaps black) but may return nil; all depends on the particulars of the given string.
      */
-    public convenience init(hexString: String) {
-        var mutableHexString = hexString
-        if mutableHexString.hasPrefix("#") {
-            mutableHexString = hexString.substringFromIndex(mutableHexString.startIndex.advancedBy(1))
+    public convenience init(hexString: String, alpha: CGFloat = 1) {
+        var hexString = hexString
+        if hexString.hasPrefix("#") {
+            hexString = hexString.substringFromIndex(hexString.startIndex.advancedBy(1))
         }
-        let scanner = NSScanner(string: mutableHexString)
+        let scanner = NSScanner(string: hexString)
         var hexEquivalent: UInt32 = 0
         scanner.scanHexInt(&hexEquivalent)
         
-        self.init(hex: hexEquivalent)
+        self.init(hex: hexEquivalent, alpha: alpha)
     }
     
     /**
@@ -167,8 +193,8 @@ extension UIColor {
      - parameter hex: The color value.
      - returns: A UIColor initialized with the given hex value.
      */
-    public static func hex(hex: UInt32) -> UIColor {
-        return UIColor(hex: hex)
+    public static func hex(hex: UInt32, alpha: CGFloat = 1) -> UIColor {
+        return UIColor(hex: hex, alpha: alpha)
     }
 }
 

--- a/Sources/UIColor+Extensions.swift
+++ b/Sources/UIColor+Extensions.swift
@@ -470,3 +470,86 @@ private func convert(cmyk c: CGFloat, _ m: CGFloat, _ y: CGFloat, _ k: CGFloat) 
 private func +(lhs: (CGFloat, CGFloat, CGFloat), rhs: CGFloat) -> (CGFloat, CGFloat, CGFloat) {
     return (lhs.0 + rhs, lhs.1 + rhs, lhs.2 + rhs)
 }
+
+// MARK: - Deprecated
+
+extension UIColor {
+    /**
+     Lightens the given color by the given percentage.
+     - parameter amount: The percentage to lighten the color by. Valid values are from 0.0 to 1.0.
+     - returns: The lightened color.
+     */
+    @available(*, deprecated=1.0.0, message="use 'lighten(by:)'")
+    public final func lighterColorByPercentage(amount: CGFloat) -> UIColor {
+        var hue: CGFloat = 1.0
+        var saturation: CGFloat = 1.0
+        var brightness: CGFloat = 1.0
+        var alpha: CGFloat = 1.0
+        
+        self.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
+        
+        return UIColor(hue: hue, saturation: saturation, brightness: min(brightness * (1 + amount), 1.0), alpha: alpha)
+    }
+    
+    /**
+     Darkens the given color by the given percentage.
+     - parameter amount: The percentage to darken the color by. Valid values are from 0.0 to 1.0.
+     - returns: The darkened color.
+     */
+    @available(*, deprecated=1.0.0, message="use 'darken(by:)'")
+    public final func darkerColorByPercentage(amount: CGFloat) -> UIColor {
+        var hue: CGFloat = 1.0
+        var saturation: CGFloat = 1.0
+        var brightness: CGFloat = 1.0
+        var alpha: CGFloat = 1.0
+        
+        self.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
+        
+        return UIColor(hue: hue, saturation: saturation, brightness: brightness * (1 - amount), alpha: alpha)
+    }
+    
+    /**
+     Returns the RGBA (red, green, blue, alpha) components.
+     - returns: The RGBA components as a tuple (r, g, b, a).
+     */
+    @available(*, unavailable, renamed="rgba")
+    public final var RGBAComponents: (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
+        return rgba
+    }
+    
+    /**
+     Returns the red component.
+     - returns: The red component as a CGFloat.
+     */
+    @available(*, deprecated=1.0.0, message="use 'rgba.r'")
+    public final var redComponent: CGFloat {
+        return rgba.r
+    }
+    
+    /**
+     Returns the green component.
+     - returns: The green component as a CGFloat.
+     */
+    @available(*, deprecated=1.0.0, message="use 'rgba.g'")
+    public final var greenComponent: CGFloat {
+        return rgba.g
+    }
+    
+    /**
+     Returns the blue component.
+     - returns: The blue component as a CGFloat.
+     */
+    @available(*, deprecated=1.0.0, message="use 'rgba.b'")
+    public final var blueComponent: CGFloat {
+        return rgba.b
+    }
+    
+    /**
+     Returns the alpha component.
+     - returns: The alpha component as a CGFloat.
+     */
+    @available(*, deprecated=1.0.0, message="use 'rgba.a'")
+    public final var alphaComponent: CGFloat {
+        return rgba.a
+    }
+}   

--- a/Sources/UIColor+Extensions.swift
+++ b/Sources/UIColor+Extensions.swift
@@ -76,35 +76,28 @@ extension UIColor {
     
     /**
      Lightens the given color by the given percentage.
-     - parameter amount: The percentage to lighten the color by. Valid values are from 0.0 to 1.0.
+     - parameter amount: The percentage by which to lighten the color. Valid values are from `0.0` to `1.0`, or for a more readable format `0%` to `100%`.
      - returns: The lightened color.
      */
-    public final func lighterColorByPercentage(amount: CGFloat) -> UIColor {
-        var hue: CGFloat = 1.0
-        var saturation: CGFloat = 1.0
-        var brightness: CGFloat = 1.0
-        var alpha: CGFloat = 1.0
+    public final func lighten(by amount: CGFloat) -> UIColor {
+        assert(amount >= 0 && amount <= 1, "Percentage must be in range 0-100%")
         
-        self.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
-        
-        return UIColor(hue: hue, saturation: saturation, brightness: min(brightness * (1 + amount), 1.0), alpha: alpha)
+        let (h, s, l) = hsl
+        return UIColor(hue: h, saturation: s, lightness: l * (1 + amount), alpha: rgba.a)
     }
     
     /**
      Darkens the given color by the given percentage.
-     - parameter amount: The percentage to darken the color by. Valid values are from 0.0 to 1.0.
+     - parameter amount: The percentage by which to darken the color. Valid values are from `0.0` to `1.0`, or for a more readable format `0%` to `100%`.
      - returns: The darkened color.
      */
-    public final func darkerColorByPercentage(amount: CGFloat) -> UIColor {
-        var hue: CGFloat = 1.0
-        var saturation: CGFloat = 1.0
-        var brightness: CGFloat = 1.0
-        var alpha: CGFloat = 1.0
+    public final func darken(by amount: CGFloat) -> UIColor {
+        assert(amount >= 0 && amount <= 1, "Percentage must be in range 0-100%")
         
-        self.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
-        
-        return UIColor(hue: hue, saturation: saturation, brightness: brightness * (1 - amount), alpha: alpha)
+        let (h, s, l) = hsl
+        return UIColor(hue: h, saturation: s, lightness: l * (1 - amount), alpha: rgba.a)
     }
+
     
     /**
      Returns the color represenation as a hexadecimal string, prefixed with '#'.

--- a/Sources/UIColor+Extensions.swift
+++ b/Sources/UIColor+Extensions.swift
@@ -198,6 +198,20 @@ extension UIColor {
     }
 }
 
+postfix operator % {}
+
+public postfix func %(value: CGFloat) -> CGFloat {
+    return value / 100
+}
+
+public postfix func %(value: Float) -> Float {
+    return value / 100
+}
+
+public postfix func %(value: Double) -> Double {
+    return value / 100
+}
+
 // MARK: - Model
 
 extension UIColor {


### PR DESCRIPTION
### Added
- Color model enum (support for rgb, hsl, hsb, cmyk, and hex)
- Computed properties on UIColor for hsl, hsb, and cmyk components
- Initializers on UIColor for hsl and cmyk
- Default `alpha` argument to existing initializers
  
### Updated
- Lighten/darken color APIs
   - The previous APIs left much to be desired, as they used a color's HSB values to adjust the lightness of the color. This led to situations where a color would not be lightened (no matter what value was specified), as shown below:
<img width="506" alt="screen shot 2016-06-18 at 10 23 48 pm" src="https://cloud.githubusercontent.com/assets/4239255/16174992/5dc02a9c-35a3-11e6-8d93-4c82e3dde944.png">
   - The updated APIs now provide expected behavior, as shown below:
<img width="426" alt="screen shot 2016-06-18 at 10 25 06 pm" src="https://cloud.githubusercontent.com/assets/4239255/16174997/8c7480f4-35a3-11e6-9571-a2a89ff0b9ff.png">
   - As shown above, there is also a new operator to make the API a bit more clear. While CGFloat values between 0.0 and 1.0 may still be used, the `%` operator may also be used to achieve the same behavior. Example: `color.darken(by: 0.5) == color.darken(by: 50%)`

### Deprecated
- `lighterColorByPercentage` and `darkerColorByPercentage`
- `RGBAComponents` (renamed to `rgba`)
- `redComponent` (in favor of `rgba.r`)
- `greenComponent` (in favor of `rgba.g`)
- `blueComponent` (in favor of `rgba.b`)