### PR TITLE
add string literal initializers to CharacterSet and URL

### DIFF
--- a/Alexandria.xcodeproj/project.pbxproj
+++ b/Alexandria.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		79B92E591C73369C0050D55B /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B92E381C73369C0050D55B /* UIView+Extensions.swift */; };
 		79B92E5A1C73369C0050D55B /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B92E391C73369C0050D55B /* UIViewController+Extensions.swift */; };
 		79FC74CA1D7600A600F06DB6 /* NSObject+Customizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FC74C91D7600A600F06DB6 /* NSObject+Customizable.swift */; };
+		811952031DC02DB900C365F1 /* URL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811952021DC02DB900C365F1 /* URL+Extensions.swift */; };
 		814C71FA1B69DD0900BB4DBD /* Alexandria.h in Headers */ = {isa = PBXBuildFile; fileRef = 814C71F91B69DD0900BB4DBD /* Alexandria.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81A87FD61D1828CD00F43B74 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A87FD51D1828CD00F43B74 /* Operators.swift */; };
 		81A87FD81D182E0800F43B74 /* CGFloatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A87FD71D182E0800F43B74 /* CGFloatTests.swift */; };
@@ -99,6 +100,7 @@
 		79B92E381C73369C0050D55B /* UIView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 		79B92E391C73369C0050D55B /* UIViewController+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extensions.swift"; sourceTree = "<group>"; };
 		79FC74C91D7600A600F06DB6 /* NSObject+Customizable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+Customizable.swift"; sourceTree = "<group>"; };
+		811952021DC02DB900C365F1 /* URL+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+Extensions.swift"; sourceTree = "<group>"; };
 		81253BDB1C69962E0054D52C /* StringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringTests.swift; sourceTree = "<group>"; };
 		81253BDD1C69A1D00054D52C /* CollectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionTests.swift; sourceTree = "<group>"; };
 		81253BDF1C69A9720054D52C /* ColorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorTests.swift; sourceTree = "<group>"; };
@@ -169,6 +171,7 @@
 				79B92E381C73369C0050D55B /* UIView+Extensions.swift */,
 				79B92E391C73369C0050D55B /* UIViewController+Extensions.swift */,
 				38ADD9CB1D1C246F0058AC28 /* UIControl+Actionable.swift */,
+				811952021DC02DB900C365F1 /* URL+Extensions.swift */,
 			);
 			path = Sources;
 			sourceTree = SOURCE_ROOT;
@@ -383,6 +386,7 @@
 				79B92E3C1C73369C0050D55B /* CAMediaTimingFunction+Extensions.swift in Sources */,
 				79B92E581C73369C0050D55B /* UITableView+Extensions.swift in Sources */,
 				79B92E431C73369C0050D55B /* Double+Extensions.swift in Sources */,
+				811952031DC02DB900C365F1 /* URL+Extensions.swift in Sources */,
 				79B92E511C73369C0050D55B /* UIFont+Extensions.swift in Sources */,
 				79B92E4B1C73369C0050D55B /* Optional+Extensions.swift in Sources */,
 				79B92E461C73369C0050D55B /* Int+Extensions.swift in Sources */,

--- a/Alexandria.xcodeproj/project.pbxproj
+++ b/Alexandria.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		814C71FA1B69DD0900BB4DBD /* Alexandria.h in Headers */ = {isa = PBXBuildFile; fileRef = 814C71F91B69DD0900BB4DBD /* Alexandria.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81A87FD61D1828CD00F43B74 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A87FD51D1828CD00F43B74 /* Operators.swift */; };
 		81A87FD81D182E0800F43B74 /* CGFloatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A87FD71D182E0800F43B74 /* CGFloatTests.swift */; };
+		81E694981DC0E893002A4EB5 /* URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E694971DC0E893002A4EB5 /* URLTests.swift */; };
+		81E6949A1DC0EA2B002A4EB5 /* CharacterSetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E694991DC0EA2B002A4EB5 /* CharacterSetTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -112,6 +114,8 @@
 		814C72061B69DD0900BB4DBD /* AlexandriaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlexandriaTests.swift; sourceTree = "<group>"; };
 		81A87FD51D1828CD00F43B74 /* Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
 		81A87FD71D182E0800F43B74 /* CGFloatTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGFloatTests.swift; sourceTree = "<group>"; };
+		81E694971DC0E893002A4EB5 /* URLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLTests.swift; sourceTree = "<group>"; };
+		81E694991DC0EA2B002A4EB5 /* CharacterSetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CharacterSetTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -238,6 +242,8 @@
 				81253BE11C69B2A20054D52C /* DateTests.swift */,
 				79B152491D01C5FC009E850E /* IntTests.swift */,
 				81A87FD71D182E0800F43B74 /* CGFloatTests.swift */,
+				81E694971DC0E893002A4EB5 /* URLTests.swift */,
+				81E694991DC0EA2B002A4EB5 /* CharacterSetTests.swift */,
 				814C72041B69DD0900BB4DBD /* Supporting Files */,
 			);
 			path = AlexandriaTests;
@@ -360,11 +366,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				81E694981DC0E893002A4EB5 /* URLTests.swift in Sources */,
 				79B1524A1D01C5FC009E850E /* IntTests.swift in Sources */,
 				796510A31C6F4F2F00E01F89 /* DateTests.swift in Sources */,
 				796510A01C6F4F2F00E01F89 /* StringTests.swift in Sources */,
 				796510A21C6F4F2F00E01F89 /* ColorTests.swift in Sources */,
 				81A87FD81D182E0800F43B74 /* CGFloatTests.swift in Sources */,
+				81E6949A1DC0EA2B002A4EB5 /* CharacterSetTests.swift in Sources */,
 				796510A11C6F4F2F00E01F89 /* CollectionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AlexandriaTests/CharacterSetTests.swift
+++ b/AlexandriaTests/CharacterSetTests.swift
@@ -1,10 +1,29 @@
 //
 //  CharacterSetTests.swift
-//  Alexandria
 //
 //  Created by Jonathan Landon on 10/26/16.
 //
+// The MIT License (MIT)
 //
+// Copyright (c) 2014-2016 Oven Bits, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import XCTest
 

--- a/AlexandriaTests/CharacterSetTests.swift
+++ b/AlexandriaTests/CharacterSetTests.swift
@@ -1,0 +1,21 @@
+//
+//  CharacterSetTests.swift
+//  Alexandria
+//
+//  Created by Jonathan Landon on 10/26/16.
+//
+//
+
+import XCTest
+
+class CharacterSetTests: XCTestCase {
+    
+    func testStringLiteralInitializer() {
+        let set: CharacterSet = "abcdefg"
+        
+        XCTAssert(set.contains("a"), "Character missing from set")
+        XCTAssert(set.contains("d"), "Character missing from set")
+        XCTAssert(!set.contains("h"), "Character should not be in set")
+    }
+    
+}

--- a/AlexandriaTests/URLTests.swift
+++ b/AlexandriaTests/URLTests.swift
@@ -1,0 +1,31 @@
+//
+//  URLTests.swift
+//  Alexandria
+//
+//  Created by Jonathan Landon on 10/26/16.
+//
+//
+
+import XCTest
+import Alexandria
+
+class URLTests: XCTestCase {
+    
+    func testStringLiteralInitializer() {
+        let url: URL = "https://github.com/ovenbits"
+        
+        XCTAssert(url.absoluteString == "https://github.com/ovenbits", "Absolute strings are not equal")
+        XCTAssert(url.scheme == "https", "Scheme are not equal")
+        XCTAssert(url.host == "github.com", "Hosts are not equal")
+        XCTAssert(url.path == "/ovenbits", "Paths are not equal")
+    }
+    
+    func testPathAppendingOperator() {
+        var url: URL = "https://github.com"
+        url = url + "ovenbits"
+        url = url + "Alexandria"
+        
+        XCTAssert(url.path == "/ovenbits/Alexandria", "Paths are not equal")
+    }
+    
+}

--- a/AlexandriaTests/URLTests.swift
+++ b/AlexandriaTests/URLTests.swift
@@ -1,10 +1,29 @@
 //
 //  URLTests.swift
-//  Alexandria
 //
 //  Created by Jonathan Landon on 10/26/16.
 //
+// The MIT License (MIT)
 //
+// Copyright (c) 2014-2016 Oven Bits, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import XCTest
 import Alexandria

--- a/Sources/CharacterSet+Extensions.swift
+++ b/Sources/CharacterSet+Extensions.swift
@@ -56,14 +56,17 @@ public extension CharacterSet {
 
 extension CharacterSet: ExpressibleByStringLiteral {
     
+    /// Creates a CharacterSet initialized to the given string value.
     public init(stringLiteral value: StringLiteralType) {
         self.init(charactersIn: value)
     }
     
+    /// Creates a CharacterSet initialized to the given value.
     public init(extendedGraphemeClusterLiteral value: StringLiteralType) {
         self.init(charactersIn: value)
     }
     
+    /// Creates a CharacterSet initialized to the given value.
     public init(unicodeScalarLiteral value: StringLiteralType) {
         self.init(charactersIn: value)
     }

--- a/Sources/CharacterSet+Extensions.swift
+++ b/Sources/CharacterSet+Extensions.swift
@@ -54,6 +54,21 @@ public extension CharacterSet {
     }
 }
 
+extension CharacterSet: ExpressibleByStringLiteral {
+    
+    public init(stringLiteral value: StringLiteralType) {
+        self.init(charactersIn: value)
+    }
+    
+    public init(extendedGraphemeClusterLiteral value: StringLiteralType) {
+        self.init(charactersIn: value)
+    }
+    
+    public init(unicodeScalarLiteral value: StringLiteralType) {
+        self.init(charactersIn: value)
+    }
+}
+
 
 /**
  Extensions to NSMutableCharacterSet

--- a/Sources/URL+Extensions.swift
+++ b/Sources/URL+Extensions.swift
@@ -1,10 +1,29 @@
 //
 //  URL+Extensions.swift
-//  Alexandria
 //
 //  Created by Jonathan Landon on 10/25/16.
 //
+// The MIT License (MIT)
 //
+// Copyright (c) 2014-2016 Oven Bits, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import Foundation
 

--- a/Sources/URL+Extensions.swift
+++ b/Sources/URL+Extensions.swift
@@ -1,0 +1,37 @@
+//
+//  URL+Extensions.swift
+//  Alexandria
+//
+//  Created by Jonathan Landon on 10/25/16.
+//
+//
+
+import Foundation
+
+extension URL: ExpressibleByStringLiteral {
+    public init(stringLiteral value: StringLiteralType) {
+        guard let url = URL(string: value) else { fatalError("Could not create URL from: \(value)") }
+        self = url
+    }
+    
+    public init(extendedGraphemeClusterLiteral value: StringLiteralType) {
+        guard let url = URL(string: value) else { fatalError("Could not create URL from: \(value)") }
+        self = url
+    }
+    
+    public init(unicodeScalarLiteral value: StringLiteralType) {
+        guard let url = URL(string: value) else { fatalError("Could not create URL from: \(value)") }
+        self = url
+    }
+}
+
+/**
+ Append a path component to a url. Equivalent to `lhs.appendingPathComponent(rhs)`.
+ 
+ - parameter lhs: The url.
+ - parameter rhs: The path component to append.
+ - returns: The original url with the appended path component.
+ */
+public func +(lhs: URL, rhs: String) -> URL {
+    return lhs.appendingPathComponent(rhs)
+}

--- a/Sources/URL+Extensions.swift
+++ b/Sources/URL+Extensions.swift
@@ -28,16 +28,19 @@
 import Foundation
 
 extension URL: ExpressibleByStringLiteral {
+    /// Creates a URL initialized to the given string value.
     public init(stringLiteral value: StringLiteralType) {
         guard let url = URL(string: value) else { fatalError("Could not create URL from: \(value)") }
         self = url
     }
     
+    /// Creates a URL initialized to the given value.
     public init(extendedGraphemeClusterLiteral value: StringLiteralType) {
         guard let url = URL(string: value) else { fatalError("Could not create URL from: \(value)") }
         self = url
     }
     
+    /// Creates a URL initialized to the given value.
     public init(unicodeScalarLiteral value: StringLiteralType) {
         guard let url = URL(string: value) else { fatalError("Could not create URL from: \(value)") }
         self = url


### PR DESCRIPTION
You can now create CharacerSets and URLs from string literals
```swift
let set: CharacterSet = "abcdefg"
let url: URL = "http://ovenbits.com"
```
Also added an operator overload for appending path components to urls
```swift
let url: URL = "https://github.com"
url + "ovenbits" // https://github.com/ovenbits
```