### PR TITLE
add UIAlertController extensions

### DIFF
--- a/Alexandria.xcodeproj/project.pbxproj
+++ b/Alexandria.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		79FC74CA1D7600A600F06DB6 /* NSObject+Customizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FC74C91D7600A600F06DB6 /* NSObject+Customizable.swift */; };
 		811952031DC02DB900C365F1 /* URL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811952021DC02DB900C365F1 /* URL+Extensions.swift */; };
 		814C71FA1B69DD0900BB4DBD /* Alexandria.h in Headers */ = {isa = PBXBuildFile; fileRef = 814C71F91B69DD0900BB4DBD /* Alexandria.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		815CA35B1DC9892400AF677B /* UIAlertController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 815CA35A1DC9892400AF677B /* UIAlertController+Extensions.swift */; };
 		81A87FD61D1828CD00F43B74 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A87FD51D1828CD00F43B74 /* Operators.swift */; };
 		81A87FD81D182E0800F43B74 /* CGFloatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A87FD71D182E0800F43B74 /* CGFloatTests.swift */; };
 		81E694981DC0E893002A4EB5 /* URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E694971DC0E893002A4EB5 /* URLTests.swift */; };
@@ -112,6 +113,7 @@
 		814C71F91B69DD0900BB4DBD /* Alexandria.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Alexandria.h; sourceTree = "<group>"; };
 		814C72051B69DD0900BB4DBD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		814C72061B69DD0900BB4DBD /* AlexandriaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlexandriaTests.swift; sourceTree = "<group>"; };
+		815CA35A1DC9892400AF677B /* UIAlertController+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Extensions.swift"; sourceTree = "<group>"; };
 		81A87FD51D1828CD00F43B74 /* Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
 		81A87FD71D182E0800F43B74 /* CGFloatTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGFloatTests.swift; sourceTree = "<group>"; };
 		81E694971DC0E893002A4EB5 /* URLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLTests.swift; sourceTree = "<group>"; };
@@ -162,6 +164,7 @@
 				79B92E291C73369C0050D55B /* Optional+Extensions.swift */,
 				79B92E2A1C73369C0050D55B /* StoreKit */,
 				79B92E2C1C73369C0050D55B /* String+Extensions.swift */,
+				815CA35A1DC9892400AF677B /* UIAlertController+Extensions.swift */,
 				79B92E2D1C73369C0050D55B /* UIButton+Extensions.swift */,
 				79B92E2E1C73369C0050D55B /* UICollectionView+Extensions.swift */,
 				79B92E2F1C73369C0050D55B /* UIColor+Extensions.swift */,
@@ -399,6 +402,7 @@
 				79B92E4B1C73369C0050D55B /* Optional+Extensions.swift in Sources */,
 				79B92E461C73369C0050D55B /* Int+Extensions.swift in Sources */,
 				79B92E3F1C73369C0050D55B /* Collection+Extensions.swift in Sources */,
+				815CA35B1DC9892400AF677B /* UIAlertController+Extensions.swift in Sources */,
 				79B92E3B1C73369C0050D55B /* CALayer+Extensions.swift in Sources */,
 				79B92E521C73369C0050D55B /* UIGestureRecognizer+Extensions.swift in Sources */,
 				79B92E411C73369C0050D55B /* CoreGraphics+Extensions.swift in Sources */,

--- a/Sources/UIAlertController+Extensions.swift
+++ b/Sources/UIAlertController+Extensions.swift
@@ -1,12 +1,32 @@
 //
 //  UIAlertController+Extensions.swift
-//  Alexandria
 //
 //  Created by Jonathan Landon on 11/1/16.
 //
+// The MIT License (MIT)
 //
+// Copyright (c) 2014-2016 Oven Bits, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import Foundation
+import UIKit
 
 extension UIAlertController {
     
@@ -31,7 +51,7 @@ extension UIAlertController {
      - parameter title: The title for the controller (optional, defaults to `nil`).
      - parameter message: The message for the controller (optional, defaults to `nil`).
      
-     - returns: A UIAlertController instances, styled as an action sheet.
+     - returns: A UIAlertController instance, styled as an action sheet.
      */
     public static func actionSheet(title: String? = nil, message: String? = nil) -> UIAlertController {
         return UIAlertController(title: title, message: message, preferredStyle: .actionSheet)
@@ -43,7 +63,7 @@ extension UIAlertController {
      - parameter title: The title for the controller (optional, defaults to `nil`).
      - parameter message: The message for the controller (optional, defaults to `nil`).
      
-     - returns: A UIAlertController instances, styled as an alert.
+     - returns: A UIAlertController instance, styled as an alert.
      */
     public static func alert(title: String? = nil, message: String? = nil) -> UIAlertController {
         return UIAlertController(title: title, message: message, preferredStyle: .alert)

--- a/Sources/UIAlertController+Extensions.swift
+++ b/Sources/UIAlertController+Extensions.swift
@@ -35,12 +35,12 @@ extension UIAlertController {
      
      - parameter title: The text to use for the action title.
      - parameter style: The style to use for the action (optional, defaults to `.default`).
-     - parameter handler: A closure to execute when the user selects the action (optional, defaults to empty closure).
+     - parameter handler: A closure to execute when the user selects the action (optional, defaults to `nil`).
      
      - returns: self
      */
     @discardableResult
-    public func addAction(title: String?, style: UIAlertActionStyle = .default, handler: @escaping (UIAlertAction) -> Void = { _ in }) -> Self {
+    public func addAction(title: String?, style: UIAlertActionStyle = .default, handler: ((UIAlertAction) -> Void)? = nil) -> Self {
         addAction(UIAlertAction(title: title, style: style, handler: handler))
         return self
     }
@@ -74,9 +74,9 @@ extension UIAlertController {
      
      - parameter controller: The controller in which to present the alert controller (optional, defaults to `.current`).
      - parameter animated: Pass `true` to animate the presentation; otherwise, pass `false` (optional, defaults to `true`).
-     - parameter completion: The closure to execute after the presentation finishes (optional, defaults to an empty closure).
+     - parameter completion: The closure to execute after the presentation finishes (optional, defaults to `nil`).
      */
-    public func present(in controller: UIViewController? = .current, animated: Bool = true, completion: @escaping () -> Void = {}) {
+    public func present(in controller: UIViewController? = .current, animated: Bool = true, completion: (() -> Void)? = nil) {
         controller?.present(self, animated: animated, completion: completion)
     }
 }

--- a/Sources/UIAlertController+Extensions.swift
+++ b/Sources/UIAlertController+Extensions.swift
@@ -1,0 +1,62 @@
+//
+//  UIAlertController+Extensions.swift
+//  Alexandria
+//
+//  Created by Jonathan Landon on 11/1/16.
+//
+//
+
+import Foundation
+
+extension UIAlertController {
+    
+    /**
+     Adds a UIAlertAction, initialized with a title, style, and completion handler.
+     
+     - parameter title: The text to use for the action title.
+     - parameter style: The style to use for the action (optional, defaults to `.default`).
+     - parameter handler: A closure to execute when the user selects the action (optional, defaults to empty closure).
+     
+     - returns: self
+     */
+    @discardableResult
+    public func addAction(title: String?, style: UIAlertActionStyle = .default, handler: @escaping (UIAlertAction) -> Void = { _ in }) -> Self {
+        addAction(UIAlertAction(title: title, style: style, handler: handler))
+        return self
+    }
+    
+    /**
+     Creates a UIAlertController instance, styled as an action sheet.
+     
+     - parameter title: The title for the controller (optional, defaults to `nil`).
+     - parameter message: The message for the controller (optional, defaults to `nil`).
+     
+     - returns: A UIAlertController instances, styled as an action sheet.
+     */
+    public static func actionSheet(title: String? = nil, message: String? = nil) -> UIAlertController {
+        return UIAlertController(title: title, message: message, preferredStyle: .actionSheet)
+    }
+    
+    /**
+     Creates a UIAlertController instance, styled as an alert.
+     
+     - parameter title: The title for the controller (optional, defaults to `nil`).
+     - parameter message: The message for the controller (optional, defaults to `nil`).
+     
+     - returns: A UIAlertController instances, styled as an alert.
+     */
+    public static func alert(title: String? = nil, message: String? = nil) -> UIAlertController {
+        return UIAlertController(title: title, message: message, preferredStyle: .alert)
+    }
+    
+    /**
+     Presents the UIAlertController inside the specified view controller.
+     
+     - parameter controller: The controller in which to present the alert controller (optional, defaults to `.current`).
+     - parameter animated: Pass `true` to animate the presentation; otherwise, pass `false` (optional, defaults to `true`).
+     - parameter completion: The closure to execute after the presentation finishes (optional, defaults to an empty closure).
+     */
+    public func present(in controller: UIViewController? = .current, animated: Bool = true, completion: @escaping () -> Void = {}) {
+        controller?.present(self, animated: animated, completion: completion)
+    }
+}


### PR DESCRIPTION
A few simple extensions on UIAlertController

Individual examples:
```swift
controller.addAction(UIAlertAction(title: "Ok", style: .default)) // before
controller.addAction(title: "Ok")                                 // after

UIAlertController(title: "Title", message: nil, preferredStyle: .alert) // before
UIAlertController.alert(title: "Title")                                 // after

UIAlertController(title: "Title", message: nil, preferredStyle: .actionSheet) // before
UIAlertController.actionSheet(title: "Title")                                 // after

UIViewController.current?.present(controller, animated: true) // before
controller.present()                                          // after
```

Full example:
```swift
// before
let controller = UIAlertController(title: "Title", message: nil, preferredStyle: .alert)
controller.addAction(UIAlertAction(title: "Ok", style: .default))
controller.addAction(UIAlertAction(title: "Cancel", style: .cancel))
UIViewController.current?.present(controller, animated: true)

// after
UIAlertController.alert(title: "Title")
                 .addAction(title: "Ok")
                 .addAction(title: "Cancel", style: .cancel)
                 .present()
```